### PR TITLE
Quick fix for checking if the function 'WebDevIconsGetFileTypeSymbol' exists

### DIFF
--- a/lua/lualine/components/branch.lua
+++ b/lua/lualine/components/branch.lua
@@ -15,7 +15,7 @@ local function Branch()
     return branch
   end
   ok = (vim.fn.exists('*WebDevIconsGetFileTypeSymbol'))
-  if ok then
+  if ok ~= 0 then
     local icon =  ''
     return icon .. ' ' .. branch
   end

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -11,7 +11,7 @@ local function Filetype()
     return filetype
     end
     ok = (vim.fn.exists('*WebDevIconsGetFileTypeSymbol'))
-    if ok then
+    if ok ~= 0 then
       local icon = vim.call('WebDevIconsGetFileTypeSymbol')
       return icon .. ' ' .. filetype
     end


### PR DESCRIPTION
When I installed this plugin without any Webdevicons plugins already installed, I received an error on opening any file due to the WebDevIcons function not existing.
 It turns out that the return from checking if the 'WebDevIconsGetFileTypeSymbol'  function exists returns a 0 if it does not exist, so I just updated accordingly.
