### PR TITLE
Added powerline theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -15,6 +15,14 @@ All available themes are only best effort ports by myself/ other users. If you f
 ![command](https://user-images.githubusercontent.com/41551030/103467919-2ba8b380-4d54-11eb-8585-6c667fd5082e.png)
 ![replace](https://user-images.githubusercontent.com/41551030/103467925-32372b00-4d54-11eb-88d6-6d39c46854d8.png)
 
+### powerline
+![normal](https://user-images.githubusercontent.com/13149513/103506288-8fcb9480-4e86-11eb-97f8-3768a34188fd.jpg)
+![insert](https://user-images.githubusercontent.com/13149513/103506295-978b3900-4e86-11eb-8eca-d31514c66275.jpg)
+![visual](https://user-images.githubusercontent.com/13149513/103506318-a40f9180-4e86-11eb-85fd-153d6de2a62f.jpg)
+![command](https://user-images.githubusercontent.com/13149513/103506333-aa057280-4e86-11eb-8098-422eca99c23a.jpg)
+![replace](https://user-images.githubusercontent.com/13149513/103506349-af62bd00-4e86-11eb-9f11-bd6a56214fa3.jpg)
+
+
 ### onedark
 ![normal](https://user-images.githubusercontent.com/41551030/103468158-a83c9180-4d56-11eb-89cb-28d802f02341.png)
 ![insert](https://user-images.githubusercontent.com/41551030/103468174-cdc99b00-4d56-11eb-8723-fd817ff06404.png)

--- a/lua/lualine/themes/powerline.lua
+++ b/lua/lualine/themes/powerline.lua
@@ -1,0 +1,88 @@
+local M = {  }
+
+local Colors = {
+  white          = '#ffffff',
+  darkestgreen   = '#005f00',
+  brightgreen    = '#afdf00',
+  darkestcyan    = '#005f5f',
+  mediumcyan     = '#87dfff',
+  darkestblue    = '#005f87',
+  darkred        = '#870000',
+  brightred      = '#df0000',
+  brightorange   = '#ff8700',
+  gray1          = '#262626',
+  gray2          = '#303030',
+  gray4          = '#585858',
+  gray5          = '#606060',
+  gray7          = '#8a8a8a',
+  gray10         = '#d0d0d0',
+}
+
+M.normal = {
+  a = {
+    fg = Colors.darkestgreen, 
+    bg = Colors.brightgreen,
+  },
+  b = {
+    fg = Colors.gray10,
+    bg = Colors.gray4,
+  },
+  c = {
+    fg = Colors.gray7,
+    bg = Colors.gray2,
+  },
+}
+
+M.insert = {
+  a = {
+    fg = Colors.darkestcyan,
+    bg = Colors.white,
+  },
+  b = {
+    fg = Colors.darkestcyan,
+    bg = Colors.mediumcyan,
+  },
+  c = {
+    fg = Colors.mediumcyan,
+    bg = Colors.darkestblue,
+  },
+}
+
+
+M.visual = {
+  a = {
+    fg = Colors.darkred,
+    bg = Colors.brightorange,
+  },
+  b = M.normal.b,
+  c = M.normal.c,
+}
+
+M.replace = {
+  a = {
+    fg = Colors.white,
+    bg = Colors.brightred,
+  },
+  b = M.normal.b,
+  c = M.normal.c,
+}
+
+M.command = M.normal  
+M.terminal = M.normal
+
+M.inactive = {
+  a = {
+    fg = Colors.gray1,
+    bg = Colors.gray5,
+  },
+  b = {
+    fg = Colors.gray1,
+    bg = Colors.gray5,
+  },
+  c = {
+    bg = Colors.gray1,
+    fg = Colors.gray5,
+  },
+}
+
+return M


### PR DESCRIPTION
### I'lll rebase the branch to current master and create another pull request



Checkout if it feels like powerline

I think mirroring theme on left(A,B,C) and right(X,Y,Z) is limiting.
I kind of like the left and right structure in lightline.
can we have something like that in lualine ?

Also I feel like the colours in normal mode should be default . if a cirtain modes values aren't defined lualine should fallback to normal modes colors.