### PR TITLE
Themes now fallback to normal mode theme

### DIFF
--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -13,10 +13,13 @@ end
 local function apply_defaults_to_theme(theme)
   local modes = {'insert', 'visual', 'replace', 'command', 'terminal', 'inactive'}
   for _, mode in ipairs(modes) do
-    theme[mode] = (theme[mode] or theme['normal'])
-    theme[mode]['a'] = (theme[mode]['a'] or theme['normal']['a'])
-    theme[mode]['b'] = (theme[mode]['b'] or theme['normal']['b'])
-    theme[mode]['c'] = (theme[mode]['c'] or theme['normal']['c'])
+    if not theme[mode] then
+      theme[mode] = theme['normal']
+    else
+      for section_name, section in pairs(theme['normal']) do
+        theme[mode][section_name] = (theme[mode][section_name] or section)
+      end
+    end
   end
   return theme
 end

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -10,7 +10,33 @@ local function highlight (name, foreground, background, special)
   return table.concat(command, ' ')
 end
 
+local function apply_defaults_to_theme(theme)
+  local modes = {'insert', 'visual', 'replace', 'command', 'terminal', 'inactive'}
+  -- normal mode cann't have a fallback for now
+  local sections = {'a', 'b', 'c'}
+  for _, mode in ipairs(modes) do
+    repeat
+      if theme[mode] == nil then
+        theme[mode] = theme['normal']
+        break
+      end
+      for _, section in ipairs(sections) do
+        repeat
+          if theme[mode][section] == nil then
+            theme[mode][section] = theme['normal'][section]
+            break
+          end
+          break
+        until true
+      end
+      break
+    until true
+  end
+  return theme
+end
+
 function M.create_highlight_groups(theme)
+  apply_defaults_to_theme(theme)
   for mode, sections in pairs(theme) do
     for section, colorscheme in pairs(sections) do
       local special = nil

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -12,25 +12,11 @@ end
 
 local function apply_defaults_to_theme(theme)
   local modes = {'insert', 'visual', 'replace', 'command', 'terminal', 'inactive'}
-  -- normal mode cann't have a fallback for now
-  local sections = {'a', 'b', 'c'}
   for _, mode in ipairs(modes) do
-    repeat
-      if theme[mode] == nil then
-        theme[mode] = theme['normal']
-        break
-      end
-      for _, section in ipairs(sections) do
-        repeat
-          if theme[mode][section] == nil then
-            theme[mode][section] = theme['normal'][section]
-            break
-          end
-          break
-        until true
-      end
-      break
-    until true
+    theme[mode] = (theme[mode] or theme['normal'])
+    theme[mode]['a'] = (theme[mode]['a'] or theme['normal']['a'])
+    theme[mode]['b'] = (theme[mode]['b'] or theme['normal']['b'])
+    theme[mode]['c'] = (theme[mode]['c'] or theme['normal']['c'])
   end
   return theme
 end


### PR DESCRIPTION
A solution to #13 

Since I'm setting defaults here, I though we could make element `(x,y,z)` default to `(c,b,a)`. And separate them in internal code . So if a theme author specifies `(x,y,z)` it statusline will be themed acording to that . otherwise left and right side will be symetrical by default .

So I've also added a implementation for   #25
