### PR TITLE
Add component for coc.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ lualine.inactive_sections = {
   * progress
 * plugin
   * signify
+  * coc
 
 </details>
 
@@ -255,7 +256,7 @@ Please create an issue/ pr if you want to see more functionality implemented
   - [x] [vim-signify](https://github.com/mhinz/vim-signify)
 - Diagnostics
   - [ ] nvim-lsp status support
-  - [ ] [coc.nvim](https://github.com/neoclide/coc.nvim)
+  - [x] [coc.nvim](https://github.com/neoclide/coc.nvim)
   - [ ] [dense-analysis/ale](https://github.com/dense-analysis/ale)
 - Themes
   - [ ] support for `notermguicolors`

--- a/lua/lualine/components/coc.lua
+++ b/lua/lualine/components/coc.lua
@@ -1,6 +1,7 @@
 local function coc_diagnostic_count(section)
-  if vim.api.nvim_eval('exists("b:coc_diagnostic_info")') == 0 then return 0 end
-  return vim.api.nvim_buf_get_var(0, 'coc_diagnostic_info')[section]
+  local info = vim.b.coc_diagnostic_info
+  if info == nil or next(info) == nil then return 0 end
+  return info[section]
 end
 
 local function coc_diagnostic(symbol, section)
@@ -14,8 +15,8 @@ local function coc_ok()
 end
 
 local function coc_status()
-  if vim.fn.exists('coc_status') == 0 then return '' end
-  return vim.api.nvim_get_var('coc_status')
+  if not vim.g.coc_status then return '' end
+  return vim.g.coc_status
 end
 
 local coc_errors = function() return coc_diagnostic('E', 'error') end

--- a/lua/lualine/components/coc.lua
+++ b/lua/lualine/components/coc.lua
@@ -1,0 +1,33 @@
+local function coc_diagnostic_count(section)
+  if vim.api.nvim_eval('exists("b:coc_diagnostic_info")') == 0 then return 0 end
+  return vim.api.nvim_buf_get_var(0, 'coc_diagnostic_info')[section]
+end
+
+local function coc_diagnostic(symbol, section)
+  local count = coc_diagnostic_count(section)
+  if count > 0 then return symbol .. ': ' .. count else return '' end
+end
+
+local function coc_ok()
+  local count = coc_diagnostic_count('error') + coc_diagnostic_count('warning')
+  if count == 0 then return '✓' else return '' end
+end
+
+local function coc_status()
+  if vim.fn.exists('coc_status') == 0 then return '' end
+  return vim.api.nvim_get_var('coc_status')
+end
+
+local coc_errors = function() return coc_diagnostic('E', 'error') end
+local coc_hints = function() return coc_diagnostic('H', 'hint') end
+local coc_infos = function() return coc_diagnostic('I', 'information') end
+local coc_warnings = function() return coc_diagnostic('W', 'warning') end
+
+local function coc()
+  return(
+    coc_status() .. coc_errors() .. coc_warnings() ..
+    coc_infos() .. coc_hints() .. coc_ok()
+  )
+end
+
+return coc


### PR DESCRIPTION
Added support for `coc.nvim`  based from my local configuration.

Some thoughts:
* I created many functions to display the status. We can separate these into 2 or more components (such as coc_status, coc_diagnostics).
* We can mimic VScode behaviour, which always shows the Error and Warning count and only shows Info and Hints if there's any.
* We can add icons

Thanks for the great plugin! Suggestions are very welcome.