### PR TITLE
Handle undefined mode && fallback to normal mode highlighting

### DIFF
--- a/lua/lualine/components/mode.lua
+++ b/lua/lualine/components/mode.lua
@@ -13,7 +13,12 @@ local function mode()
     ['t']  = 'TERMINAL',
     ['s']  = 'SELECT',
   }
-  return mode_map[vim.fn.mode()]
+  local function get_mode()
+    local mode_code = vim.api.nvim_get_mode().mode
+    if mode_map[mode_code] == nil then return mode_code end
+    return mode_map[mode_code]
+  end
+  return get_mode()
 end
 
 return mode

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -49,9 +49,9 @@ function M.format_highlight(is_focused, highlight_group)
     elseif mode == 'V-REPLACE' then
       highlight_group = highlight_group .. '_replace'
     elseif mode == 'SELECT' then
-      highlight_group = highlight_group .. '_terminal'
+      highlight_group = highlight_group .. '_visual'
     else
-      highlight_group = highlight_group .. '_' .. mode:lower()
+      highlight_group = highlight_group .. '_normal'
     end
   end
   highlight_group = highlight_group .. [[#]]


### PR DESCRIPTION
regarding #35 

I donn't think all the modes make sence .
We could add the nessary modes to the list . And handle the other so they donn't make lualine crash .
This patch makes the modes that aren't defined to use normal mode highlighting.

Also I've switched select mode to use visual mode highlighting.