### PR TITLE
Fixed signify component apearing on non repo buffer

### DIFF
--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -1,13 +1,6 @@
 local function signify()
-   if vim.fn.exists('*sy#repo#get_stats') == 0 then return '' end
-   local added, modified, removed = unpack(vim.fn['sy#repo#get_stats']())
-   if added == -1 then return '' end
-   local data = {
-    '+', added,
-    '~', modified,
-    '-', removed
-   }
-  return table.concat(data, ' ')
+   local ok, result = pcall(vim.fn['sy#repo#get_stats_decorated'])
+   if ok then return result else return '' end
 end
 
 return signify

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -3,9 +3,9 @@ local function signify()
    local added, modified, removed = unpack(vim.fn['sy#repo#get_stats']())
    if added == -1 then return '' end
    local data = {
-    '+', added,
-    '~', modified,
-    '-', removed
+    '+'..added,
+    '-'..removed
+    '~'..modified,
    }
   return table.concat(data, ' ')
 end

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -1,9 +1,7 @@
 local function signify()
    if vim.fn.exists('*sy#repo#get_stats') == 0 then return '' end
    local added, modified, removed = unpack(vim.fn['sy#repo#get_stats']())
-   if added == -1 then added = 0 end
-   if modified == -1 then modified = 0 end
-   if removed == -1 then removed = 0 end
+   if added == -1 then return '' end
    local data = {
     '+', added,
     '~', modified,

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -1,6 +1,13 @@
 local function signify()
-   local ok, result = pcall(vim.fn['sy#repo#get_stats_decorated'])
-   if ok then return result else return '' end
+   if vim.fn.exists('*sy#repo#get_stats') == 0 then return '' end
+   local added, modified, removed = unpack(vim.fn['sy#repo#get_stats']())
+   if added == -1 then return '' end
+   local data = {
+    '+', added,
+    '~', modified,
+    '-', removed
+   }
+  return table.concat(data, ' ')
 end
 
 return signify

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -4,7 +4,7 @@ local function signify()
    if added == -1 then return '' end
    local data = {
     '+'..added,
-    '-'..removed
+    '-'..removed,
     '~'..modified,
    }
   return table.concat(data, ' ')


### PR DESCRIPTION
fixing #50
[added, modified, removed] = [-1, -1, -1] was a error code that was
being ignored

I think we should use sy#repo#get_stats_decorated()
insted of sy#repo#get_stats()