### PR TITLE
Add codedark theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -8,6 +8,12 @@ All available themes are only best effort ports by myself/ other users. If you f
 ![visual](https://user-images.githubusercontent.com/13149513/104338631-e852ff80-5520-11eb-9341-0ecd87aed656.jpg)
 ![replace](https://user-images.githubusercontent.com/13149513/104338654-eee17700-5520-11eb-9ff3-d2308d1243e5.jpg)
 
+### codedark
+![normal](https://user-images.githubusercontent.com/22453358/106365012-66920d00-633b-11eb-97a2-a10a0c48b1dc.png)
+![insert](https://user-images.githubusercontent.com/22453358/106365022-7b6ea080-633b-11eb-92ef-57254fe1df1a.png)
+![visual](https://user-images.githubusercontent.com/22453358/106365017-6f82de80-633b-11eb-864b-490bfac0af05.png)
+![replace](https://user-images.githubusercontent.com/22453358/106365034-904b3400-633b-11eb-8677-7c6ace953bb0.png)
+
 ### dracula
 ![normal](https://user-images.githubusercontent.com/41551030/103468233-2d27ab00-4d57-11eb-8f3c-36426dd2f053.png)
 ![insert](https://user-images.githubusercontent.com/41551030/103468255-49c3e300-4d57-11eb-9e7a-2df1bf047465.png)

--- a/lua/lualine/themes/codedark.lua
+++ b/lua/lualine/themes/codedark.lua
@@ -1,0 +1,41 @@
+local codedark = {}
+
+local colors = {
+  gray     = "#3C3C3C",
+  lightred = "#D16969",
+  blue     = "#569CD6",
+  pink     = "#C586C0",
+  black    = "#262626",
+  white    = "#D4D4D4",
+  green    = "#608B4E",
+}
+
+codedark.normal = {
+  b = { fg = colors.green, bg = colors.black },
+  a = { fg = colors.black, bg = colors.green , "bold", },
+  c = { fg = colors.white, bg = colors.black },
+}
+
+codedark.visual = {
+  b = { fg = colors.pink, bg = colors.black },
+  a = { fg = colors.black, bg = colors.pink , "bold", },
+}
+
+codedark.inactive = {
+  b = { fg = colors.black, bg = colors.blue },
+  a = { fg = colors.white, bg = colors.gray , "bold", },
+}
+
+codedark.replace = {
+  b = { fg = colors.lightred, bg = colors.black },
+  a = { fg = colors.black, bg = colors.lightred , "bold", },
+  c = { fg = colors.white, bg = colors.black },
+}
+
+codedark.insert = {
+  b = { fg = colors.blue, bg = colors.black },
+  a = { fg = colors.black, bg = colors.blue , "bold", },
+  c = { fg = colors.white, bg = colors.black },
+}
+
+return codedark


### PR DESCRIPTION
![normal](https://user-images.githubusercontent.com/22453358/106365012-66920d00-633b-11eb-97a2-a10a0c48b1dc.png)
![insert](https://user-images.githubusercontent.com/22453358/106365022-7b6ea080-633b-11eb-92ef-57254fe1df1a.png)
![visual](https://user-images.githubusercontent.com/22453358/106365017-6f82de80-633b-11eb-864b-490bfac0af05.png)
![replace](https://user-images.githubusercontent.com/22453358/106365034-904b3400-633b-11eb-8677-7c6ace953bb0.png)

Ported from [vim-code-dark](https://github.com/tomasiser/vim-code-dark) using [lightline2lualine_theme_converter.lua](https://gist.github.com/shadmansaleh/000871c9a608a012721c6acc6d7a19b9).