### PR TITLE
Don't show signify status symbols if the count < 1

### DIFF
--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -15,7 +15,7 @@ local function signify()
    }
    for range=1,3 do
      if data[range] ~= nil and data[range] > 0
-       then table.insert(result,symbols[range]..blank..data[range]..blank)
+       then table.insert(result,symbols[range]..' '..data[range]..' ')
      end
    end
 

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -15,7 +15,7 @@ local function signify()
    }
    for range=1,3 do
      if data[range] ~= nil and data[range] > 0
-       then table.insert(result,symbols[range]..' '..data[range]..' ')
+       then table.insert(result,symbols[range]..''..data[range]..' ')
      end
    end
 

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -2,12 +2,29 @@ local function signify()
    if vim.fn.exists('*sy#repo#get_stats') == 0 then return '' end
    local added, modified, removed = unpack(vim.fn['sy#repo#get_stats']())
    if added == -1 then return '' end
-   local data = {
-    '+'..added,
-    '-'..removed,
-    '~'..modified,
+   local symbols = {
+     '+',
+     '-',
+     '~',
    }
-  return table.concat(data, ' ')
+   local result = {}
+   local data = {
+    added,
+    removed,
+    modified,
+   }
+   for range=1,3 do
+     if data[range] ~= nil and data[range] > 0
+       then table.insert(result,symbols[range]..blank..data[range]..blank)
+     end
+   end
+
+   if result[1] ~= nil then
+       return table.concat(result, '')
+   else
+       return ''
+   end
 end
+
 
 return signify


### PR DESCRIPTION
It is not very informative to have indicators in our statusline that tell us that there are 0 deletions or additions etc. This proposed change will only display relevant indicators if they have a count > 0. This leads to a cleaner statusline that is less cluttered and removes the dreaded '+0 -0 ~1' scenarios. Instead, only '~1' would show in that instance 😀