### PR TITLE
Load lualine asyncronasly to improve startup

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -1,5 +1,5 @@
-local utils = require('lualine.utils')
-local highlight = require('lualine.highlight')
+local utils
+local highlight
 
 local M = { }
 
@@ -114,12 +114,19 @@ local function exec_autocommands()
 end
 
 function M.status()
-  load_components()
-  load_extensions()
-  set_lualine_theme()
-  exec_autocommands()
-  _G.lualine_statusline = status_dispatch
-  vim.o.statusline = '%!v:lua.lualine_statusline()'
+  local async_loader
+  async_loader = vim.loop.new_async(vim.schedule_wrap(function()
+    utils = require('lualine.utils')
+    highlight = require('lualine.highlight')
+    exec_autocommands()
+    set_lualine_theme()
+    load_components()
+    load_extensions()
+    _G.lualine_statusline = status_dispatch
+    vim.o.statusline = '%!v:lua.lualine_statusline()'
+    async_loader:close()
+  end))
+  async_loader:send()
 end
 
 return M


### PR DESCRIPTION
Well I've moved component and other loadings to a async. So Startup should be faster .
` nvim --startuptime` 
[tweekmonster/startuptime.vim](https://github.com/tweekmonster/startuptime.vim)
[norcalli/profiler.nvim](https://github.com/norcalli/profiler.nvim)
Does show startuptime improvements . 

Though I donn't have much experience in async. You can check it out if profilers are fooled or startup time actually improves . Though since lualine is already quite fast so I guess improvement isn't that huge . But in future newer components will add to that time . Also code complexcity isn't realy increased so I think it's a good idea to load lualine asyncronusly . 
