### PR TITLE
Powerline like section seperators v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ lualine.component_separators = {'', ''}
 or disable it
 
 ```lua
-lualine.section_separators = {'', ''}
-lualine.component_separators = {'', ''}
+lualine.section_separators = nil
+lualine.component_separators = nil
 ```
 
 ### Changing components in lualine sections

--- a/README.md
+++ b/README.md
@@ -86,17 +86,19 @@ All available themes are listed in [THEMES.md](./THEMES.md)
 Please create a pr if you managed to port a popular theme before me, [here is how to do it](./CONTRIBUTING.md).
 
 ### Changing separator in section
-Lualine defines a separator between components in given section, the default
-separator is `|`. You can change the separator this way:
+Lualine defines two kinds of seperators. One is for sections and other is for components. Default section seperators are '', '' and component separators are '', ''.
+They require powerline patched fonts. But you can easily change yours to something else like below
 
 ```lua
-lualine.options.separator = '|'
+lualine.section_separators = {'', ''}
+lualine.component_separators = {'', ''}
 ```
 
 or disable it
 
 ```lua
-lualine.options.separator = ''
+lualine.section_separators = {'', ''}
+lualine.component_separators = {'', ''}
 ```
 
 ### Changing components in lualine sections
@@ -292,7 +294,8 @@ All available extensions are listed in [EXTENSIONS.md](./EXTENSIONS.md)
       local lualine = require('lualine')
       lualine.options = {
         theme = 'gruvbox',
-        separator = '|',
+        section_separators = {'', ''},
+        component_separators = {'', ''},
         icons_enabled = true,
       }
       lualine.sections = {
@@ -329,7 +332,8 @@ lua << EOF
 local lualine = require('lualine')
     lualine.options = {
       theme = 'gruvbox',
-      separator = '|',
+      section_separators = {'', ''},
+      component_separators = {'', ''},
       icons_enabled = true,
     }
     lualine.sections = {

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -123,8 +123,8 @@ easily change yours to something else like below.
 
 or disable it
 >
-    lualine.section_separators = {'', ''}
-    lualine.component_separators = {'', ''}
+    lualine.section_separators = nil
+    lualine.component_separators = nil
 <
 
 CHANGING COMPONENTS IN LUALINE SECTIONS            *lualine-changing_components*

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -113,15 +113,19 @@ how to do it (./CONTRIBUTING.md).
 
 CHANGING SEPARATOR IN SECTION			    *lualine-changing_separator*
 
-Lualine defines a separator between components in given section, the default
-separator is `|`. You can change the separator this way:
+Lualine defines two kinds of seperators. One is for sections and other is
+for components. Default section seperators are '', '' and component
+separators are '', ''.They require powerline patched fonts. But you can
+easily change yours to something else like below.
 >
-    lualine.options.separator = '|'
+    lualine.section_separators = {'', ''}
+    lualine.component_separators = {'', ''}
 <
 
 or disable it
 >
-    lualine.options.separator = ''
+    lualine.section_separators = {'', ''}
+    lualine.component_separators = {'', ''}
 <
 
 CHANGING COMPONENTS IN LUALINE SECTIONS            *lualine-changing_components*
@@ -332,7 +336,8 @@ packer config
           local lualine = require('lualine')
 	  lualine.options = {
 	    theme = 'gruvbox',
-	    separator = '|',
+	    section_separators = {'', ''},
+	    component_separators = {'', ''},
 	    icons_enabled = true,
 	  }
           lualine.sections = {
@@ -368,9 +373,10 @@ vimrc config
     local lualine = require('lualine')
         lualine.options = {
           theme = 'gruvbox',
-          separator = '|',
-          icons_enabled = true,
-        }
+	    section_separators = {'', ''},
+	    component_separators = {'', ''},
+	    icons_enabled = true,
+	  }
         lualine.sections = {
           lualine_a = { 'mode' },
           lualine_b = { 'branch' },

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -235,37 +235,38 @@ local function statusline(sections, is_focused)
   end
   -- incase none of x,y,z was configured lets not fill whole statusline with a,b,c section
   if not half_passed then
-    table.insert(status, highlight.format_highlight(is_focused,'lualine_c').."%=") end
-    return table.concat(status)
+    table.insert(status, highlight.format_highlight(is_focused,'lualine_c').."%=")
   end
+  return table.concat(status)
+end
 
-  local function status_dispatch()
-    if vim.g.statusline_winid == vim.fn.win_getid() then
-      return statusline(M.sections, true)
-    else
-      return statusline(M.inactive_sections, false)
-    end
+local function status_dispatch()
+  if vim.g.statusline_winid == vim.fn.win_getid() then
+    return statusline(M.sections, true)
+  else
+    return statusline(M.inactive_sections, false)
   end
+end
 
-  local function exec_autocommands()
-    _G.lualine_set_theme = lualine_set_theme
-    _G.lualine_statusline = status_dispatch
-    vim.api.nvim_exec([[
-    augroup lualine
-    autocmd!
-    autocmd ColorScheme * call v:lua.lualine_set_theme()
-    autocmd WinLeave,BufLeave * lua vim.wo.statusline=lualine_statusline()
-    autocmd WinEnter,BufEnter * setlocal statusline=%!v:lua.lualine_statusline()
-    augroup END
-    ]], false)
-  end
+local function exec_autocommands()
+  _G.lualine_set_theme = lualine_set_theme
+  _G.lualine_statusline = status_dispatch
+  vim.api.nvim_exec([[
+  augroup lualine
+  autocmd!
+  autocmd ColorScheme * call v:lua.lualine_set_theme()
+  autocmd WinLeave,BufLeave * lua vim.wo.statusline=lualine_statusline()
+  autocmd WinEnter,BufEnter * setlocal statusline=%!v:lua.lualine_statusline()
+  augroup END
+  ]], false)
+end
 
-  function M.status()
-    check_single_separator()
-    lualine_set_theme()
-    exec_autocommands()
-    load_components()
-    load_extensions()
-  end
+function M.status()
+  check_single_separator()
+  lualine_set_theme()
+  exec_autocommands()
+  load_components()
+  load_extensions()
+end
 
-  return M
+return M

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -60,7 +60,7 @@ local function load_special_components(component)
       -- filters var portion from g:var
       -- For some reason overwriting component var from outer scope causes the
       -- component not to work . So creating a new local name component to use:/
-      local component = component:sub(#scope + 2, #component)
+      component = component:sub(#scope + 2, #component)
       -- Displays nothing when veriable aren't present
       local return_val = vim[scope][component]
       if return_val == nil then return '' end

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -157,14 +157,14 @@ local function statusline(sections, is_focused)
   -- The sequence sections should maintain
   local section_sequence = {'a', 'b', 'c', 'x', 'y', 'z'}
 
-  for _, sec in ipairs(section_sequence) do
-    if sections['lualine_'..sec] then
+  for _, section_name in ipairs(section_sequence) do
+    if sections['lualine_'..section_name] then
       -- insert highlight+components of this section to status_builder
-      local hl = highlight.format_highlight(is_focused,
-                   'lualine_'..sec)
-			local section = utils_component.draw_section(sections['lualine_'..sec], hl)
-			if #section > 0 then
-				table.insert(status_builder, {sec, section})
+      local section_highlight = highlight.format_highlight(is_focused,
+                   'lualine_'..section_name)
+			local section_data = utils_component.draw_section(sections['lualine_'..section_name], section_highlight)
+			if #section_data > 0 then
+				table.insert(status_builder, {section_name, section_data})
 			end
     end
   end
@@ -182,22 +182,26 @@ local function statusline(sections, is_focused)
     if is_focused then
       -- component separator needs to have fg = current_section.bg
       -- and bg = adjacent_section.bg
-      local prev_section = status_builder[i-1] and status_builder[i-1] or {nil, nil}
-      local cur_section = status_builder[i]
-      local next_section = status_builder[i+1] and status_builder[i+1] or {nil, nil}
+      local previous_section = status_builder[i-1] and status_builder[i-1] or {}
+      local current_section = status_builder[i]
+      local next_section = status_builder[i+1] and status_builder[i+1] or {}
       -- For 2nd half we need to show separator before section
-      if cur_section[1] > 'x' then
-        local hl = highlight.get_transitional_highlights(prev_section[2], cur_section[2], true)
-        if hl then table.insert(status, hl .. M.options.section_separators[2]) end
+      if current_section[1] > 'x' then
+        local transitional_highlight = highlight.get_transitional_highlights(previous_section[2], current_section[2], true)
+        if transitional_highlight and M.options.section_separators and M.options.section_separators[2] then
+          table.insert(status, transitional_highlight .. M.options.section_separators[2])
+        end
       end
 
       -- **( insert the actual section in the middle )** --
       table.insert(status, status_builder[i][2])
 
       -- For 1st half we need to show separator after section
-      if cur_section[1] < 'c' then
-        local hl = highlight.get_transitional_highlights(cur_section[2], next_section[2])
-        if hl then table.insert(status, hl .. M.options.section_separators[1]) end
+      if current_section[1] < 'c' then
+        local transitional_highlight = highlight.get_transitional_highlights(current_section[2], next_section[2])
+        if transitional_highlight and M.options.section_separators and M.options.section_separators[1] then
+          table.insert(status, transitional_highlight .. M.options.section_separators[1])
+        end
       end
     else -- when not in focus
       table.insert(status, status_builder[i][2])

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -12,8 +12,10 @@ local theme_set = {}
 M.options = {
   icons_enabled = true,
   theme = 'gruvbox',
-  separator = '|',
+	component_separators = {'', ''},
+	section_separators = {'', ''},
 }
+
 
 M.sections = {
   lualine_a = { 'mode' },
@@ -150,32 +152,57 @@ local function statusline(sections, is_focused)
   if M.theme ~= theme_set then
     set_lualine_theme()
   end
+  -- status_builder stores statusline without section_separators
+  local status_builder = {}
+  -- The sequence sections should maintain
+  local section_sequence = {'a', 'b', 'c', 'x', 'y', 'z'}
+
+  for _, sec in ipairs(section_sequence) do
+    if sections['lualine_'..sec] then
+      -- insert highlight+components of this section to status_builder
+      local highlight = highlight.format_highlight(is_focused,
+                   'lualine_'..sec)
+      table.insert(status_builder, {sec, utils_component.draw_section(sections['lualine_'..sec], highlight)})
+    end
+  end
+
+  -- Actual statusline
   local status = {}
-  if sections.lualine_a then
-    local hl = highlight.format_highlight(is_focused, 'lualine_a')
-    table.insert(status, utils_component.draw_section(sections.lualine_a,  hl))
+  local half_passed = false
+  for i=1,#status_builder do
+    -- midsection divider
+    if not half_passed and status_builder[i][1] > 'c' then
+      table.insert(status, highlight.format_highlight(is_focused, 'lualine_c') .. '%=')
+      half_passed = true
+    end
+    -- provide section_separators when statusline is in focus
+    if is_focused then
+      -- component separator needs to have fg = current_section.bg
+      -- and bg = adjacent_section.bg
+      local prev_section = status_builder[i-1] and status_builder[i-1] or {[2] = nil}
+      local cur_section = status_builder[i]
+      local next_section = status_builder[i+1] and status_builder[i+1] or {[2] = nil}
+      -- For 2nd half we need to show separator before section
+      if cur_section[1] > 'x' then
+        local hl = highlight.get_transitional_highlights(prev_section[2], cur_section[2], true)
+        if hl then table.insert(status, hl .. M.options.section_separators[2]) end
+      end
+
+      -- **( insert the actual section in the middle )** --
+      table.insert(status, status_builder[i][2])
+
+      -- For 1st half we need to show separator after section
+      if cur_section[1] < 'c' then
+        local hl = highlight.get_transitional_highlights(cur_section[2], next_section[2])
+        if hl then table.insert(status, hl .. M.options.section_separators[1]) end
+      end
+    else -- when not in focus
+      table.insert(status, status_builder[i][2])
+    end
   end
-  if sections.lualine_b then
-    local hl = highlight.format_highlight(is_focused, 'lualine_b')
-    table.insert(status, utils_component.draw_section(sections.lualine_b,  hl))
-  end
-  if sections.lualine_c then
-    local hl = highlight.format_highlight(is_focused, 'lualine_c')
-    table.insert(status, utils_component.draw_section(sections.lualine_c,  hl))
-  end
-  table.insert(status, "%=")
-  if sections.lualine_x then
-    local hl = highlight.format_highlight(is_focused, 'lualine_c')
-    table.insert(status, utils_component.draw_section(sections.lualine_x,  hl))
-  end
-  if sections.lualine_y then
-    local hl = highlight.format_highlight(is_focused, 'lualine_b')
-    table.insert(status, utils_component.draw_section(sections.lualine_y,  hl))
-  end
-  if sections.lualine_z then
-    local hl = highlight.format_highlight(is_focused, 'lualine_a')
-    table.insert(status, utils_component.draw_section(sections.lualine_z,  hl))
-  end
+  -- incase none of x,y,z was configured lets not fill whole statusline with a,b,c section
+  if not half_passed then
+    table.insert(status, highlight.format_highlight(is_focused,'lualine_c').."%=") end
   return table.concat(status)
 end
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -162,7 +162,10 @@ local function statusline(sections, is_focused)
       -- insert highlight+components of this section to status_builder
       local highlight = highlight.format_highlight(is_focused,
                    'lualine_'..sec)
-      table.insert(status_builder, {sec, utils_component.draw_section(sections['lualine_'..sec], highlight)})
+			local section = utils_component.draw_section(sections['lualine_'..sec], highlight)
+			if #section > 0 then
+				table.insert(status_builder, {sec, section})
+			end
     end
   end
 

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -140,7 +140,7 @@ local function  load_extensions()
   end
 end
 
-local function set_lualine_theme()
+local function lualine_set_theme()
   if type(M.options.theme) == 'string' then
     M.options.theme = require('lualine.themes.'.. M.options.theme)
   end
@@ -150,7 +150,7 @@ end
 
 local function statusline(sections, is_focused)
   if M.theme ~= theme_set then
-    set_lualine_theme()
+    _G.lualine_set_theme()
   end
   -- status_builder stores statusline without section_separators
   local status_builder = {}
@@ -222,12 +222,12 @@ local function status_dispatch()
 end
 
 local function exec_autocommands()
-  _G.set_lualine_theme = set_lualine_theme
+  _G.lualine_set_theme = lualine_set_theme
   _G.lualine_statusline = status_dispatch
   vim.api.nvim_exec([[
     augroup lualine
     autocmd!
-    autocmd ColorScheme * call v:lua.set_lualine_theme()
+    autocmd ColorScheme * call v:lua.lualine_set_theme()
     autocmd WinLeave,BufLeave * lua vim.wo.statusline=lualine_statusline()
     autocmd WinEnter,BufEnter * setlocal statusline=%!v:lua.lualine_statusline()
     augroup END
@@ -235,7 +235,7 @@ local function exec_autocommands()
 end
 
 function M.status()
-  set_lualine_theme()
+  lualine_set_theme()
   exec_autocommands()
   load_components()
   load_extensions()

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -160,9 +160,9 @@ local function statusline(sections, is_focused)
   for _, sec in ipairs(section_sequence) do
     if sections['lualine_'..sec] then
       -- insert highlight+components of this section to status_builder
-      local highlight = highlight.format_highlight(is_focused,
+      local hl = highlight.format_highlight(is_focused,
                    'lualine_'..sec)
-			local section = utils_component.draw_section(sections['lualine_'..sec], highlight)
+			local section = utils_component.draw_section(sections['lualine_'..sec], hl)
 			if #section > 0 then
 				table.insert(status_builder, {sec, section})
 			end
@@ -182,9 +182,9 @@ local function statusline(sections, is_focused)
     if is_focused then
       -- component separator needs to have fg = current_section.bg
       -- and bg = adjacent_section.bg
-      local prev_section = status_builder[i-1] and status_builder[i-1] or {[2] = nil}
+      local prev_section = status_builder[i-1] and status_builder[i-1] or {nil, nil}
       local cur_section = status_builder[i]
-      local next_section = status_builder[i+1] and status_builder[i+1] or {[2] = nil}
+      local next_section = status_builder[i+1] and status_builder[i+1] or {nil, nil}
       -- For 2nd half we need to show separator before section
       if cur_section[1] > 'x' then
         local hl = highlight.get_transitional_highlights(prev_section[2], cur_section[2], true)

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -60,7 +60,7 @@ local function load_special_components(component)
       -- filters var portion from g:var
       -- For some reason overwriting component var from outer scope causes the
       -- component not to work . So creating a new local name component to use:/
-      component = component:sub(#scope + 2, #component)
+      local component = component:sub(#scope + 2, #component)
       -- Displays nothing when veriable aren't present
       local return_val = vim[scope][component]
       if return_val == nil then return '' end

--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -143,13 +143,25 @@ end
 local function lualine_set_theme()
   if type(M.options.theme) == 'string' then
     M.options.theme = require('lualine.themes.'.. M.options.theme)
+    local function reset_component_theme(sections)
+      for _, section in pairs(sections)do
+        for _, component in pairs(section) do
+          if type(component) == 'table' then
+            component.theme = M.options.theme
+          end
+        end
+      end
+    end
+    reset_component_theme(M.sections)
+    reset_component_theme(M.inactive_sections)
   end
+  highlight.clear_highlights()
   highlight.create_highlight_groups(M.options.theme)
   theme_set = M.options.theme
 end
 
 local function statusline(sections, is_focused)
-  if M.theme ~= theme_set then
+  if M.options.theme ~= theme_set then
     _G.lualine_set_theme()
   end
   -- status_builder stores statusline without section_separators

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -36,7 +36,6 @@ local function signify(options)
   if options.colored then
     create_highlights()
     utils.expand_set_theme(create_highlights)
-    options.custom_highlight = true
   end
 
   -- Function that runs everytime statusline is updated

--- a/lua/lualine/components/signify.lua
+++ b/lua/lualine/components/signify.lua
@@ -12,13 +12,13 @@ local function signify(options)
   if options.colored == nil then options.colored = true end
   -- apply colors
   if not options.color_added then
-    options.color_added = utils.extract_highlight_colors('diffAdded', 'foreground') or default_color_added
+    options.color_added = utils.extract_highlight_colors('diffAdded', 'guifg') or default_color_added
   end
   if not options.color_modified then
-    options.color_modified = utils.extract_highlight_colors('diffChanged', 'foreground') or default_color_modified
+    options.color_modified = utils.extract_highlight_colors('diffChanged', 'guifg') or default_color_modified
   end
   if not options.color_removed then
-    options.color_removed = utils.extract_highlight_colors('diffRemoved', 'foreground') or default_color_removed
+    options.color_removed = utils.extract_highlight_colors('diffRemoved', 'guifg') or default_color_removed
   end
 
   local highlights = {}

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -153,17 +153,17 @@ function M.format_highlight(is_focused, highlight_group)
 end
 
 -- @description : Provides transitional highlights for section separators.
--- @param left_section :(string) section before separator
--- @param right_section:(string) section after separator
+-- @param left_section_data :(string) section before separator
+-- @param right_section_data:(string) section after separator
 -- @param reverse      :(string) Whether it's a left separator or right separator
 --		'▶️' and '◀️' needs reverse colors so this parameter needs to be set true.
 -- @return: (string) formated highlight group name
-function M.get_transitional_highlights(left_section, right_section, reverse )
+function M.get_transitional_highlights(left_section_data, right_section_data, reverse )
   local left_highlight_name, right_highlight_name
   -- Grab the last highlighter of left section
-  if left_section then
+  if left_section_data then
     -- extract highlight_name from .....%#highlight_name#
-    left_highlight_name = left_section:match('.*%%#(.*)#')
+    left_highlight_name = left_section_data:match('.*%%#(.*)#')
   else
     -- When right section us unavailable default to lualine_c
     left_highlight_name = append_mode('lualine_c')
@@ -171,10 +171,10 @@ function M.get_transitional_highlights(left_section, right_section, reverse )
       left_highlight_name = 'lualine_c_normal'
     end
   end
-  if right_section then
+  if right_section_data then
     -- using vim-regex cause lua-paterns don't have non-greedy matching
     -- extract highlight_name from %#highlight_name#....
-    right_highlight_name = vim.fn.matchlist(right_section, [[%#\(.\{-\}\)#]])[2]
+    right_highlight_name = vim.fn.matchlist(right_section_data, [[%#\(.\{-\}\)#]])[2]
   else
     -- When right section us unavailable default to lualine_c
     right_highlight_name = append_mode('lualine_c')

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -37,7 +37,22 @@ local function highlight (name, foreground, background, gui)
   table.insert(loaded_highlights, name)
 end
 
+local function apply_defaults_to_theme(theme)
+  local modes = {'insert', 'visual', 'replace', 'command', 'terminal', 'inactive'}
+  for _, mode in ipairs(modes) do
+    if not theme[mode] then
+      theme[mode] = theme['normal']
+    else
+      for section_name, section in pairs(theme['normal']) do
+        theme[mode][section_name] = (theme[mode][section_name] or section)
+      end
+    end
+  end
+  return theme
+end
+
 function M.create_highlight_groups(theme)
+  apply_defaults_to_theme(theme)
   for mode, sections in pairs(theme) do
     for section, colorscheme in pairs(sections) do
       local highlight_group_name = { 'lualine', section, mode }
@@ -141,15 +156,11 @@ function M.format_highlight(is_focused, highlight_group)
   end
   local highlight_name = highlight_group
   if not is_focused then
-    highlight_name = highlight_group .. [[_inactive]]
+    return '%#' .. highlight_group .. [[_inactive#]]
   else
     highlight_name = append_mode(highlight_group)
   end
-  if utils.highlight_exists(highlight_name) then
-    return '%#' .. highlight_name ..'#'
-  else
-    return '%#' .. highlight_group .. '_normal#'
-  end
+  return '%#' .. highlight_name ..'#'
 end
 
 -- @description : Provides transitional highlights for section separators.

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -145,6 +145,12 @@ function M.get_transitional_highlights(left_section, right_section, reverse )
   if left_section then
     -- extract highlight_name from .....%#highlight_name#
     left_highlight_name = left_section:match('.*%%#(.*)#')
+  else
+    -- When right section us unavailable default to lualine_c
+    left_highlight_name = append_mode('lualine_c')
+    if vim.fn.hlexists(left_highlight_name) == 0 then
+      left_highlight_name = 'lualine_c_normal'
+    end
   end
   if right_section then
     -- using vim-regex cause lua-paterns don't have non-greedy matching
@@ -174,8 +180,8 @@ function M.get_transitional_highlights(left_section, right_section, reverse )
     local function set_transitional_highlights()
       -- Get colors from highlights
       -- using string.format to convert decimal to hexadecimal
-      local fg = string.format('#%06x', vim.api.nvim_get_hl_by_name(left_highlight_name, true).background)
-      local bg = string.format('#%06x', vim.api.nvim_get_hl_by_name(right_highlight_name, true).background)
+      local fg = utils.extract_highlight_colors(left_highlight_name, 'background')
+      local bg = utils.extract_highlight_colors(right_highlight_name, 'background')
 			-- swap the bg and fg when reverse is true. As in that case highlight will
 			-- be placed before section
 			if reverse then fg, bg = bg, fg end

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -180,8 +180,8 @@ function M.get_transitional_highlights(left_section, right_section, reverse )
     local function set_transitional_highlights()
       -- Get colors from highlights
       -- using string.format to convert decimal to hexadecimal
-      local fg = utils.extract_highlight_colors(left_highlight_name, 'background')
-      local bg = utils.extract_highlight_colors(right_highlight_name, 'background')
+      local fg = utils.extract_highlight_colors(left_highlight_name, 'guibg')
+      local bg = utils.extract_highlight_colors(right_highlight_name, 'guibg')
 			-- swap the bg and fg when reverse is true. As in that case highlight will
 			-- be placed before section
 			if reverse then fg, bg = bg, fg end

--- a/lua/lualine/utils/component.lua
+++ b/lua/lualine/utils/component.lua
@@ -45,10 +45,25 @@ end
 -- Apply separator at end of component only when
 -- custom highlights haven't affected background
 local function apply_spearator(status, options)
-  if options.separator and #options.separator > 0 and
-     (not options.color or not options.color.bg) then
-    status = status .. options.separator
-    options.separator_applied = true
+    local sep
+    if options.separator and #options.separator > 0 then
+      sep = options.separator
+    elseif options.component_separators then
+      if options.self.section < 'lualine_x' then sep = options.component_separators[1]
+      else sep = options.component_separators[2] end
+      options.separator = sep
+    else
+      return status
+    end
+    status = status .. sep
+    options.separator_applied = sep
+  return status
+end
+
+function strip_separator(status, options)
+  if options.separator_applied then
+    status = status:sub(1, #status - #options.separator_applied)
+    options.separator_applied = nil
   end
   return status
 end
@@ -56,12 +71,11 @@ end
 -- Returns formated string for a section
 function M.draw_section(section, highlight)
   local status = {}
+  local drawn_components = {}
   for _, component in pairs(section) do
-    -- Reset flags
-    component.drawn = false -- Flag to check if a component was drawn or not
-    component.separator_applied = false -- Flag to check if separator was applied
     local localstatus = component[1]()
     if #localstatus > 0 then
+      local custom_hl = localstatus:find('%%#.*#') == 1 or component.color ~= nil
       -- Apply modifier functions for options
       if component.format then localstatus = component.format(localstatus) end
       localstatus = apply_icon(localstatus, component)
@@ -69,26 +83,25 @@ function M.draw_section(section, highlight)
       localstatus = apply_padding(localstatus, component)
       localstatus = apply_highlights(localstatus, component)
       localstatus = apply_spearator(localstatus, component)
-      table.insert(status, localstatus)
-      component.drawn = true
+      if custom_hl then table.insert(status, localstatus)
+      else table.insert(status, highlight .. localstatus) end
+      table.insert(drawn_components, component)
     end
   end
   -- Draw nothing when all the components were empty
   if #status == 0 then return '' end
-  -- convert to single string
-  -- highlight is used as separator so custom highlights don't affect
-  -- later components
-  local status_str = highlight .. table.concat(status, highlight)
-  -- Remove separator from last drawn component if available
-  for last_component = #section, 1, -1 do
-    if section[last_component].drawn then
-      if section[last_component].separator_applied then
-        status_str = status_str:sub(1, #status_str - #section[last_component].separator)
+  -- Remove separators sorounding custom highlighted component
+  for i=1,#status do
+    if (drawn_components[i].color and drawn_components[i].color.bg)
+      or drawn_components[i].custom_highlight then
+      status[i] = strip_separator(status[i], drawn_components[i])
+      if i > 1 then
+        status[i - 1] = strip_separator(status[i - 1], drawn_components[i - 1])
       end
-      break
     end
   end
-  return status_str
+  status[#status] = strip_separator(status[#status], drawn_components[#status])
+  return table.concat(status)
 end
 
 

--- a/lua/lualine/utils/component.lua
+++ b/lua/lualine/utils/component.lua
@@ -44,23 +44,25 @@ end
 
 -- Apply separator at end of component only when
 -- custom highlights haven't affected background
-local function apply_spearator(status, options)
-    local sep
+local function apply_spearator(status, options, highlight_name)
+    local separator
     if options.separator and #options.separator > 0 then
-      sep = options.separator
+      separator = options.separator
     elseif options.component_separators then
-      if options.self.section < 'lualine_x' then sep = options.component_separators[1]
-      else sep = options.component_separators[2] end
-      options.separator = sep
+      if options.self.section < 'lualine_x' then separator = options.component_separators[1]
+      else separator = options.component_separators[2] end
+      if not separator then return status end
+      options.separator = separator
     else
       return status
     end
-    status = status .. sep
-    options.separator_applied = sep
+    separator = highlight_name .. separator
+    status = status .. separator
+    options.separator_applied = separator
   return status
 end
 
-function strip_separator(status, options)
+local function strip_separator(status, options)
   if options.separator_applied then
     status = status:sub(1, #status - #options.separator_applied)
     options.separator_applied = nil
@@ -69,7 +71,7 @@ function strip_separator(status, options)
 end
 
 -- Returns formated string for a section
-function M.draw_section(section, highlight)
+function M.draw_section(section, highlight_name)
   local status = {}
   local drawn_components = {}
   for _, component in pairs(section) do
@@ -82,9 +84,9 @@ function M.draw_section(section, highlight)
       localstatus = apply_case(localstatus, component)
       localstatus = apply_padding(localstatus, component)
       localstatus = apply_highlights(localstatus, component)
-      localstatus = apply_spearator(localstatus, component)
+      localstatus = apply_spearator(localstatus, component, highlight_name)
       if custom_hl then table.insert(status, localstatus)
-      else table.insert(status, highlight .. localstatus) end
+      else table.insert(status, highlight_name .. localstatus) end
       table.insert(drawn_components, component)
     end
   end

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -7,8 +7,8 @@ local M = {}
 -- functionality at runtime .
 function M.expand_set_theme(func)
   -- execute a local version of global function to not get in a inf recurtion
-  local set_theme = _G.set_lualine_theme
-  _G.set_lualine_theme = function()
+  local set_theme = _G.lualine_set_theme
+  _G.lualine_set_theme = function()
     set_theme()
     func()
   end

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -16,7 +16,7 @@ end
 
 -- Note for now only works for termguicolors scope can be background or foreground
 function M.extract_highlight_colors(color_group, scope)
-  if vim.fn.hlexists(color_group) == 0 then return nil end
+  if not M.highlight_exists(color_group) then return nil end
   local gui_colors = vim.api.nvim_get_hl_by_name(color_group, true)
   local cterm_colors = vim.api.nvim_get_hl_by_name(color_group, false)
   local color = {
@@ -36,6 +36,13 @@ function M.extract_highlight_colors(color_group, scope)
   color = vim.tbl_extend('keep', color, gui_colors, cterm_colors)
   if scope then return color[scope] end
   return color
+end
+
+-- determine if an highlight exist and isn't cleared
+function M.highlight_exists(highlight_name)
+  local ok, result = pcall(vim.api.nvim_exec, 'highlight '..highlight_name, true)
+  if not ok then return false end
+  return result:find('xxx cleared') == nil
 end
 
 return M

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -42,8 +42,7 @@ end
 function M.highlight_exists(highlight_name)
   local ok, result = pcall(vim.api.nvim_exec, 'highlight '..highlight_name, true)
   if not ok then return false end
-  local return_val = result:find('xxx cleared') == nil
-  return return_val
+  return result:find('xxx cleared') == nil
 end
 
 return M

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -42,7 +42,8 @@ end
 function M.highlight_exists(highlight_name)
   local ok, result = pcall(vim.api.nvim_exec, 'highlight '..highlight_name, true)
   if not ok then return false end
-  return result:find('xxx cleared') == nil
+  local return_val = result:find('xxx cleared') == nil
+  return return_val
 end
 
 return M

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -16,6 +16,7 @@ end
 
 -- Note for now only works for termguicolors scope can be background or foreground
 function M.extract_highlight_colors(color_group, scope)
+  if vim.fn.hlexists(color_group) == 0 then return nil end
   local color = string.format('#%06x', vim.api.nvim_get_hl_by_name(color_group, true)[scope])
   return color or nil
 end

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -17,8 +17,25 @@ end
 -- Note for now only works for termguicolors scope can be background or foreground
 function M.extract_highlight_colors(color_group, scope)
   if vim.fn.hlexists(color_group) == 0 then return nil end
-  local color = string.format('#%06x', vim.api.nvim_get_hl_by_name(color_group, true)[scope])
-  return color or nil
+  local gui_colors = vim.api.nvim_get_hl_by_name(color_group, true)
+  local cterm_colors = vim.api.nvim_get_hl_by_name(color_group, false)
+  local color = {
+    ctermfg = cterm_colors.foreground,
+    ctermbg = cterm_colors.background,
+  }
+  if gui_colors.background then
+    color.guibg = string.format('#%06x', gui_colors.background)
+    gui_colors.background = nil
+  end
+  if gui_colors.foreground then
+    color.guifg = string.format('#%06x', gui_colors.foreground)
+    gui_colors.foreground = nil
+  end
+  cterm_colors.background = nil
+  cterm_colors.foreground = nil
+  color = vim.tbl_extend('keep', color, gui_colors, cterm_colors)
+  if scope then return color[scope] end
+  return color
 end
 
 return M


### PR DESCRIPTION
It's basicaly merge of #55 and #60 + some fixes and improvements.

![demo.jpg](https://user-images.githubusercontent.com/13149513/107920945-f10f7900-6f97-11eb-97f6-06924604785d.jpg)


The #55 couldn't handle special highlighting in #60 there were some conflits too , I've fixed it .

Changes:
- added component separators{left, right}
- added section separators{left, right}
- We were creating too many unnessary highlight groups (for providing defaults) . I've changed that . removed `apply_defaults` function from highlights.lua . Defaults are handled by `format_highlight` function directly
- Added `get_transition_highlight` function that provides highlight groups for section_separator.
- Other miscellanious changes to make everything work


**for review**:
Changes are confined in:
- lua/lualine.lua 
- lua/lualine/highlight.lua
- lua/lualine/utils/component.lua

**Notes:** If custom haghlights are managed by component itself and not using color option and changing components background color.  it should set custom_highlight option to true. So component separators aren't displayed .


@hoob3rt  you sould merge it after #60