### PR TITLE
Enhancement: Stop creating unnececery hl groups

### DIFF
--- a/lua/lualine.lua
+++ b/lua/lualine.lua
@@ -154,6 +154,8 @@ end
 local function lualine_set_theme()
   if type(M.options.theme) == 'string' then
     M.options.theme = require('lualine.themes.'.. M.options.theme)
+    -- change the theme table in component so their custom
+    -- highlights can reflect theme change
     local function reset_component_theme(sections)
       for _, section in pairs(sections)do
         for _, component in pairs(section) do
@@ -166,7 +168,7 @@ local function lualine_set_theme()
     reset_component_theme(M.sections)
     reset_component_theme(M.inactive_sections)
   end
-  highlight.clear_highlights()
+  utils.clear_highlights()
   highlight.create_highlight_groups(M.options.theme)
   theme_set = M.options.theme
 end

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -5,17 +5,6 @@ local M = {  }
 local utils_colors = require "lualine.utils.cterm_colors"
 local utils = require 'lualine.utils.utils'
 local section_highlight_map = {x = 'c', y = 'b', z = 'a'}
-local loaded_highlights = {}
-
--- @description: clears Highlights in loaded_highlights
-function M.clear_highlights()
-  for no, highlight_name in ipairs(loaded_highlights)do
-    if highlight_name and #highlight_name > 0 and utils.highlight_exists(highlight_name) then
-      vim.cmd('highlight clear ' .. highlight_name)
-    end
-    loaded_highlights[no] = nil
-  end
-end
 
 local function highlight (name, foreground, background, gui)
   local command = { 'highlight', name, }
@@ -34,25 +23,10 @@ local function highlight (name, foreground, background, gui)
     table.insert(command, 'gui=' .. (gui or 'none'))
   end
   vim.cmd(table.concat(command, ' '))
-  table.insert(loaded_highlights, name)
-end
-
-local function apply_defaults_to_theme(theme)
-  local modes = {'insert', 'visual', 'replace', 'command', 'terminal', 'inactive'}
-  for _, mode in ipairs(modes) do
-    if not theme[mode] then
-      theme[mode] = theme['normal']
-    else
-      for section_name, section in pairs(theme['normal']) do
-        theme[mode][section_name] = (theme[mode][section_name] or section)
-      end
-    end
-  end
-  return theme
+  utils.save_highlight(name)
 end
 
 function M.create_highlight_groups(theme)
-  apply_defaults_to_theme(theme)
   for mode, sections in pairs(theme) do
     for section, colorscheme in pairs(sections) do
       local highlight_group_name = { 'lualine', section, mode }
@@ -156,11 +130,14 @@ function M.format_highlight(is_focused, highlight_group)
   end
   local highlight_name = highlight_group
   if not is_focused then
-    return '%#' .. highlight_group .. [[_inactive#]]
+    highlight_name =  highlight_group .. [[_inactive]]
   else
     highlight_name = append_mode(highlight_group)
   end
-  return '%#' .. highlight_name ..'#'
+  if utils.highlight_exists(highlight_name) then
+    return '%#' .. highlight_name .. '#'
+  end
+  return '%#' .. highlight_group ..'_normal#'
 end
 
 -- @description : Provides transitional highlights for section separators.

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -16,7 +16,7 @@ end
 
 -- Note for now only works for termguicolors scope can be background or foreground
 function M.extract_highlight_colors(color_group, scope)
-  if not M.highlight_exists(color_group) then return nil end
+  if vim.fn.hlexists(color_group) == 0 then return nil end
   local gui_colors = vim.api.nvim_get_hl_by_name(color_group, true)
   local cterm_colors = vim.api.nvim_get_hl_by_name(color_group, false)
   local color = {
@@ -38,11 +38,25 @@ function M.extract_highlight_colors(color_group, scope)
   return color
 end
 
+-- table to store the highlight names created by lualine
+M.loaded_highlights = {}
+
+-- sets loaded_highlights table
+function M.save_highlight(highlight_name)
+  M.loaded_highlights[highlight_name] = true
+end
+
+-- clears loaded_highlights table and highlights
+function M.clear_highlights()
+  for highlight_name, _ in pairs(M.loaded_highlights)do
+    vim.cmd('highlight clear ' .. highlight_name)
+    M.loaded_highlights[highlight_name] = nil
+  end
+end
+
 -- determine if an highlight exist and isn't cleared
 function M.highlight_exists(highlight_name)
-  local ok, result = pcall(vim.api.nvim_exec, 'highlight '..highlight_name, true)
-  if not ok then return false end
-  return result:find('xxx cleared') == nil
+  return M.loaded_highlights[highlight_name] and true or false
 end
 
 return M


### PR DESCRIPTION
- defaults for themes are directly handled
  insted of creating highlight groups for
  all posibilities

This was part of separator pr you merged today . I held it back in last moment as I couldn;t resolve a bug . No that bug has been resolved

@hoob3rt can you merge this quickly 