### PR TITLE
Refactor: removing cterm colors from themes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,6 @@
 
 To create a custom theme you need to define a colorscheme for each of vim's modes. Each mode has a `fg` and `bg` field for every lualine section.
 You can add special effects with `gui`.
-You can provide colors in two ways
-  1. As a table like `{'hexcode', 256_color_code}`
-  2. As a String like `'hexcode'`
-Note : You can use `lualine.util.get_cterm_color(hex_color)` function to genarate 256_color_codes from hex_codes.
-  When method 2 is used 256_color_codes are genarated with that .
 
 Adding theme is really easy in lua. Here is and example of a gruvbox theme.
 
@@ -31,15 +26,12 @@ Adding theme is really easy in lua. Here is and example of a gruvbox theme.
 local gruvbox = {  }
 
 local colors = {
- -- color format { hex_color, 256_color_code}
-  black        = {"#282828", 235},
-  white        = {'#ebdbb2', 223},
-  red          = {'#fb4934', 203},
-  green        = {'#b8bb26', 143},
-  blue         = {'#83a598', 108},
-  yellow       = {'#fe8019', 209},
-
-  -- color format 'hex_color'
+  black        = "#282828",
+  white        = '#ebdbb2',
+  red          = '#fb4934',
+  green        = '#b8bb26',
+  blue         = '#83a598',
+  yellow       = '#fe8019',
   gray         = '#a89984',
   darkgray     = '#3c3836',
   lightgray    = '#504945',

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -8,19 +8,17 @@ local section_highlight_map = {x = 'c', y = 'b', z = 'a'}
 
 local function highlight (name, foreground, background, gui)
   local command = { 'highlight', name, }
-  if foreground then
-    table.insert(command, 'ctermfg=' .. (foreground[2] or
-      (foreground ~= 'none' and utils_colors.get_cterm_color(foreground)) or 'none'))
-    table.insert(command, 'guifg=' .. (foreground[1] or foreground))
+  if foreground and foreground ~= 'none' then
+    table.insert(command, 'ctermfg=' .. utils_colors.get_cterm_color(foreground))
+    table.insert(command, 'guifg=' .. foreground)
   end
-  if background then
-    table.insert(command, 'ctermbg=' .. (background[2] or
-      (background ~= 'none' and utils_colors.get_cterm_color(background)) or 'none'))
-    table.insert(command, 'guibg=' .. (background[1] or background))
+  if background and background ~= 'none' then
+    table.insert(command, 'ctermbg=' .. utils_colors.get_cterm_color(background))
+    table.insert(command, 'guibg=' .. background)
   end
   if gui then
-    table.insert(command, 'cterm=' .. (gui or 'none'))
-    table.insert(command, 'gui=' .. (gui or 'none'))
+    table.insert(command, 'cterm=' .. gui )
+    table.insert(command, 'gui=' .. gui )
   end
   vim.cmd(table.concat(command, ' '))
   utils.save_highlight(name)

--- a/lua/lualine/themes/16color.lua
+++ b/lua/lualine/themes/16color.lua
@@ -5,22 +5,22 @@
 local M = {}
 
 local colors = {
-  black   = { '#000000', 0 },
-  maroon  = { '#800000', 1 },
-  green   = { '#008000', 2 },
-  olive   = { '#808000', 3 },
-  navy    = { '#000080', 4 },
-  purple  = { '#800080', 5 },
-  teal    = { '#008080', 6 },
-  silver  = { '#c0c0c0', 7 },
-  gray    = { '#808080', 8},
-  red     = { '#ff0000', 9 },
-  lime    = { '#00ff00', 10 },
-  yellow  = { '#ffff00', 11 },
-  blue    = { '#0000ff', 12 },
-  fuchsia = { '#ff00ff', 13 },
-  aqua    = { '#00ffff', 14 },
-  white   = { '#ffffff', 15 },
+  black   = '#000000',
+  maroon  = '#800000',
+  green   = '#008000',
+  olive   = '#808000',
+  navy    = '#000080',
+  purple  = '#800080',
+  teal    = '#008080',
+  silver  = '#c0c0c0',
+  gray    = '#808080',
+  red     = '#ff0000',
+  lime    = '#00ff00',
+  yellow  = '#ffff00',
+  blue    = '#0000ff',
+  fuchsia = '#ff00ff',
+  aqua    = '#00ffff',
+  white   = '#ffffff',
 }
 
 M.normal = {

--- a/lua/lualine/themes/dracula.lua
+++ b/lua/lualine/themes/dracula.lua
@@ -5,15 +5,15 @@
 local dracula = {}
 
 local colors = {
-  grey       = {"#44475a", 238},
-  light_gray = {"#5f6a8e", 60 },
-  orange     = {"#ffb86c", 215},
-  purple     = {"#bd93f9", 141},
-  red        = {"#ff5555", 203},
-  yellow     = {"#f1fa8c", 228},
-  green      = {"#50fa7b", 84 },
-  white      = {"#f8f8f2", 255},
-  black      = {"#282a36", 236},
+  grey       = "#44475a",
+  light_gray = "#5f6a8e",
+  orange     = "#ffb86c",
+  purple     = "#bd93f9",
+  red        = "#ff5555",
+  yellow     = "#f1fa8c",
+  green      = "#50fa7b",
+  white      = "#f8f8f2",
+  black      = "#282a36",
 }
 
 dracula.normal = {

--- a/lua/lualine/themes/forest_night.lua
+++ b/lua/lualine/themes/forest_night.lua
@@ -4,16 +4,16 @@
 local forest_night = {}
 
 local colors = {
-  bg0    = {"#323d43", 237},
-  bg1    = {"#3c474d", 238},
-  bg3    = {"#505a60", 240},
-  fg     = {"#d8caac", 187},
-  aqua   = {"#87c095", 108},
-  green  = {"#a7c080", 144},
-  orange = {"#e39b7b", 180},
-  purple = {"#d39bb6", 181},
-  red    = {"#e68183", 174},
-  grey1  = {"#868d80", 102},
+  bg0    = "#323d43",
+  bg1    = "#3c474d",
+  bg3    = "#505a60",
+  fg     = "#d8caac",
+  aqua   = "#87c095",
+  green  = "#a7c080",
+  orange = "#e39b7b",
+  purple = "#d39bb6",
+  red    = "#e68183",
+  grey1  = "#868d80",
 }
 
 forest_night.normal = {

--- a/lua/lualine/themes/gruvbox.lua
+++ b/lua/lualine/themes/gruvbox.lua
@@ -4,16 +4,16 @@
 local gruvbox = {}
 
 local colors = {
-  black        = {"#282828", 235},
-  white        = {'#ebdbb2', 223},
-  red          = {'#fb4934', 203},
-  green        = {'#b8bb26', 143},
-  blue         = {'#83a598', 108},
-  yellow       = {'#fe8019', 209},
-  gray         = {'#a89984', 144},
-  darkgray     = {'#3c3836', 237},
-  lightgray    = {'#504945', 239},
-  inactivegray = {'#7c6f64', 242},
+  black        = "#282828",
+  white        = '#ebdbb2',
+  red          = '#fb4934',
+  green        = '#b8bb26',
+  blue         = '#83a598',
+  yellow       = '#fe8019',
+  gray         = '#a89984',
+  darkgray     = '#3c3836',
+  lightgray    = '#504945',
+  inactivegray = '#7c6f64',
 }
 
 gruvbox.normal = {

--- a/lua/lualine/themes/gruvbox_material.lua
+++ b/lua/lualine/themes/gruvbox_material.lua
@@ -2,7 +2,7 @@
 -- MIT license, see LICENSE for more details.
 
 local colors = {
-  fg1 = "#282828",
+  fg1    = "#282828",
   color2 = "#504945",
   fg2    = "#ddc7a1",
   color3 = "#32302f",

--- a/lua/lualine/themes/molokai.lua
+++ b/lua/lualine/themes/molokai.lua
@@ -5,15 +5,15 @@
 local molokai = {}
 
 local colors = {
-  black  = { '#232526', 233 },
-  gray   = { '#808080', 244 },
-  white  = { '#f8f8f2', 234 },
-  cyan   = { '#66d9ef', 81  },
-  green  = { '#a6e22e', 118 },
-  orange = { '#ef5939', 166 },
-  pink   = { '#f92672', 161 },
-  red    = { '#ff0000', 160 },
-  yellow = { '#e6db74', 229 },
+  black  = '#232526',
+  gray   = '#808080',
+  white  = '#f8f8f2',
+  cyan   = '#66d9ef',
+  green  = '#a6e22e',
+  orange = '#ef5939',
+  pink   = '#f92672',
+  red    = '#ff0000',
+  yellow = '#e6db74',
 }
 
 molokai.normal = {

--- a/lua/lualine/themes/nord.lua
+++ b/lua/lualine/themes/nord.lua
@@ -4,13 +4,13 @@
 local nord = {}
 
 local colors = {
-  nord1  = {"#3B4252", 237},
-  nord3  = {"#4C566A", 240},
-  nord5  = {"#E5E9F0", 254},
-  nord6  = {"#ECEFF4", 255},
-  nord7  = {"#8FBCBB", 158},
-  nord8  = {"#88C0D0", 159},
-  nord13 = {"#EBCB8B", 221},
+  nord1  = "#3B4252",
+  nord3  = "#4C566A",
+  nord5  = "#E5E9F0",
+  nord6  = "#ECEFF4",
+  nord7  = "#8FBCBB",
+  nord8  = "#88C0D0",
+  nord13 = "#EBCB8B",
 }
 
 nord.normal = {

--- a/lua/lualine/themes/onedark.lua
+++ b/lua/lualine/themes/onedark.lua
@@ -5,17 +5,17 @@
 local M = {}
 
 local colors = {
-  blue   = { '#61afef', 75 },
-  green  = { '#98c379', 76 },
-  purple = { '#c678dd', 176 },
-  red1   = { '#e06c75', 168 },
-  red2   = { '#be5046', 168 },
-  yellow = { '#e5c07b', 180 },
-  fg    = { '#abb2bf', 145 },
-  bg    = { '#282c34', 235 },
-  gray1 = { '#5c6370', 241 },
-  gray2 = { '#2c323d', 235 },
-  gray3 = { '#3e4452', 240 },
+  blue   = '#61afef',
+  green  = '#98c379',
+  purple = '#c678dd',
+  red1   = '#e06c75',
+  red2   = '#be5046',
+  yellow = '#e5c07b',
+  fg     = '#abb2bf',
+  bg     = '#282c34',
+  gray1  = '#5c6370',
+  gray2  = '#2c323d',
+  gray3  = '#3e4452',
 }
 
 M.normal = {

--- a/lua/lualine/themes/onelight.lua
+++ b/lua/lualine/themes/onelight.lua
@@ -5,17 +5,17 @@
 local M = {}
 
 local colors = {
-  blue   = { '#61afef', 75 },
-  green  = { '#98c379', 35 },
-  purple = { '#c678dd', 176 },
-  red1   = { '#e06c75', 168 },
-  red2   = { '#be5046', 168 },
-  yellow = { '#e5c07b', 180 },
-  fg    = { '#494b53', 238 },
-  bg    = { '#fafafa', 255 },
-  gray1 = { '#494b53', 238 },
-  gray2 = { '#f0f0f0', 255 },
-  gray3 = { '#d0d0d0', 250 },
+  blue   = '#61afef',
+  green  = '#98c379',
+  purple = '#c678dd',
+  red1   = '#e06c75',
+  red2   = '#be5046',
+  yellow = '#e5c07b',
+  fg     = '#494b53',
+  bg     = '#fafafa',
+  gray1  = '#494b53',
+  gray2  = '#f0f0f0',
+  gray3  = '#d0d0d0',
 }
 
 M.normal = {

--- a/lua/lualine/themes/powerline.lua
+++ b/lua/lualine/themes/powerline.lua
@@ -4,21 +4,21 @@
 local powerline = {  }
 
 local Colors = {
-  white          = {'#ffffff', 231},
-  darkestgreen   = {'#005f00', 22 },
-  brightgreen    = {'#afdf00', 148},
-  darkestcyan    = {'#005f5f', 23 },
-  mediumcyan     = {'#87dfff', 117},
-  darkestblue    = {'#005f87', 24 },
-  darkred        = {'#870000', 88 },
-  brightred      = {'#df0000', 160},
-  brightorange   = {'#ff8700', 214},
-  gray1          = {'#262626', 235},
-  gray2          = {'#303030', 236},
-  gray4          = {'#585858', 240},
-  gray5          = {'#606060', 241},
-  gray7          = {'#9e9e9e', 245},
-  gray10         = {'#f0f0f0', 252},
+  white          = '#ffffff',
+  darkestgreen   = '#005f00',
+  brightgreen    = '#afdf00',
+  darkestcyan    = '#005f5f',
+  mediumcyan     = '#87dfff',
+  darkestblue    = '#005f87',
+  darkred        = '#870000',
+  brightred      = '#df0000',
+  brightorange   = '#ff8700',
+  gray1          = '#262626',
+  gray2          = '#303030',
+  gray4          = '#585858',
+  gray5          = '#606060',
+  gray7          = '#9e9e9e',
+  gray10         = '#f0f0f0',
 }
 
 powerline.normal = {

--- a/lua/lualine/themes/solarized_light.lua
+++ b/lua/lualine/themes/solarized_light.lua
@@ -5,14 +5,14 @@
 local M = {}
 
 local colors = {
-  base3  =  '#002b36',
-  base2  =  '#073642',
-  base1  =  '#586e75',
-  base0  =  '#657b83',
-  base00   =  '#839496',
-  base01   =  '#93a1a1',
-  base02   =  '#eee8d5',
-  base03   =  '#fdf6e3',
+  base3   =  '#002b36',
+  base2   =  '#073642',
+  base1   =  '#586e75',
+  base0   =  '#657b83',
+  base00  =  '#839496',
+  base01  =  '#93a1a1',
+  base02  =  '#eee8d5',
+  base03  =  '#fdf6e3',
   yellow  =  '#b58900',
   orange  =  '#cb4b16',
   red     =  '#dc322f',

--- a/lua/lualine/themes/wombat.lua
+++ b/lua/lualine/themes/wombat.lua
@@ -5,22 +5,22 @@
 local M = {}
 
 local colors = {
-  base03  = { '#242424', 235 },
-  base023 = { '#353535', 236 },
-  base02  = { '#444444', 238 },
-  base01  = { '#585858', 240 },
-  base00  = { '#666666', 242 },
-  base0   = { '#808080', 244 },
-  base1   = { '#969696', 247 },
-  base2   = { '#a8a8a8', 248 },
-  base3   = { '#d0d0d0', 252 },
-  yellow  = { '#cae682', 180 },
-  orange  = { '#e5786d', 173 },
-  red     = { '#e5786d', 203 },
-  magenta = { '#f2c68a', 216 },
-  blue    = { '#8ac6f2', 117 },
-  cyan    = { '#8ac6f2', 117 },
-  green   = { '#95e454', 119 },
+  base03  = '#242424',
+  base023 = '#353535',
+  base02  = '#444444',
+  base01  = '#585858',
+  base00  = '#666666',
+  base0   = '#808080',
+  base1   = '#969696',
+  base2   = '#a8a8a8',
+  base3   = '#d0d0d0',
+  yellow  = '#cae682',
+  orange  = '#e5786d',
+  red     = '#e5786d',
+  magenta = '#f2c68a',
+  blue    = '#8ac6f2',
+  cyan    = '#8ac6f2',
+  green   = '#95e454',
 }
 
 M.normal = {


### PR DESCRIPTION
Addressing issue #110

#### Changes
- Removed cterm values from themes
- highlight function nolonger accepts cterm colors insted they are always genarated
- removed cterm color related instructions from CONTRIBUTING.md