### PR TITLE
Enable to set symbols for diff component

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ colored | true | displays diff status in color if set to `true` |
 color_added | `DiffAdd` foreground color | changes diff's added section foreground color | color in `#rrggbb` format
 color_modified | `DiffChange` foreground color | changes diff's changed section foreground color | color in `#rrggbb` format
 color_removed | `DiffDelete` foreground color | changes diff's removed section foreground color | color in `#rrggbb` format
+symbols | `{added = '+', modified = '~', removed = '-'}` | changes diff's symbols | table containing on or more symbols |
 
 
 ##### Component options example

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -332,12 +332,28 @@ List of options are given below.
 
     • color_added (DiffAdd foreground color)
       Foreground color of added section
+      Color in #rrggbb format
 
     • color_modified (DiffChange foreground color)
       Foreground color of modified section
+      Color in #rrggbb format
 
     • color_removed (DiffDelete foreground color)
       Foreground color of removed section
+      Color in #rrggbb format
+
+    • symbols ({added = '+', modified = '~', removed = '-'})
+      Changes diff's symbol characters. You can set some symbols partly.
+      Color in #rrggbb format
+      >
+	  {
+	    'diff',
+	    -- set the added symbol and use defaults for modified and removed.
+	    symbols = {
+	      added = 'A',
+	    },
+	  }
+<
 
 Example:~
 >


### PR DESCRIPTION
Changes logic to store diffs in `git_diff` because the original has
stored them in a list:

```
{1, 2, 3} => {added = 1, modified = 2, removed = 3}
```