### PR TITLE
Refactor: Highlight restoring after ColorScheme

### DIFF
--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -80,7 +80,7 @@ local function diagnostics(options)
   end
 
   local highlight_groups = {}
-  local function add_highlights()
+  if options.colored then
     highlight_groups = {
       error = highlight.create_component_highlight_group(
           {fg = options.color_error}, 'diagnostics_error', options),
@@ -89,11 +89,6 @@ local function diagnostics(options)
       info = highlight.create_component_highlight_group(
           {fg = options.color_info}, 'diagnostics_info', options)
     }
-  end
-
-  if options.colored then
-    add_highlights()
-    utils.expand_set_theme(add_highlights)
   end
 
   return function()

--- a/lua/lualine/components/diff.lua
+++ b/lua/lualine/components/diff.lua
@@ -108,7 +108,7 @@ local function diff(options)
   local highlights = {}
 
   -- create highlights and save highlight_name in highlights table
-  local function create_highlights()
+  if options.colored then
     highlights = {
       added = highlight.create_component_highlight_group(
           {fg = options.color_added}, 'diff_added', options),
@@ -124,12 +124,6 @@ local function diff(options)
     autocmd lualine BufEnter     * lua require'lualine.components.diff'.update_git_diff()
     autocmd lualine BufWritePost * lua require'lualine.components.diff'.update_git_diff()
     ]], false)
-
-  -- create highlights
-  if options.colored then
-    create_highlights()
-    utils.expand_set_theme(create_highlights)
-  end
 
   -- Function that runs everytime statusline is updated
   return function()

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -1,6 +1,5 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
-local utils = require('lualine.utils.utils')
 local utils_section = require('lualine.utils.section')
 local highlight = require('lualine.highlight')
 local config = require('lualine.defaults')
@@ -122,13 +121,9 @@ local function component_loader(component)
     end
     -- set custom highlights
     if component.color then
-      local function update_color()
-        component.color_highlight = highlight.create_component_highlight_group(
-                                        component.color,
-                                        component.component_name, component)
-      end
-      update_color()
-      utils.expand_set_theme(update_color)
+      component.color_highlight = highlight.create_component_highlight_group(
+                                      component.color,
+                                      component.component_name, component)
     end
   end
 end
@@ -160,27 +155,6 @@ local function load_extensions()
     load_sections(local_extension.inactive_sections)
     config.extensions[index] = local_extension
   end
-end
-
-local function lualine_set_theme()
-  if type(config.options.theme) == 'string' then
-    config.options.theme = require('lualine.themes.' .. config.options.theme)
-    -- change the theme table in component so their custom
-    -- highlights can reflect theme change
-    local function reset_component_theme(sections)
-      for _, section in pairs(sections) do
-        for _, component in pairs(section) do
-          if type(component) == 'table' then
-            component.theme = config.options.theme
-          end
-        end
-      end
-    end
-    reset_component_theme(config.sections)
-    reset_component_theme(config.inactive_sections)
-  end
-  utils.clear_highlights()
-  highlight.create_highlight_groups(config.options.theme)
 end
 
 local function statusline(sections, is_focused)
@@ -296,12 +270,14 @@ end
 local function tabline() return statusline(config.tabline, true) end
 
 local function setup_theme()
-  lualine_set_theme()
-  _G.lualine_set_theme = lualine_set_theme
+  if type(config.options.theme) == 'string' then
+    config.options.theme = require('lualine.themes.' .. config.options.theme)
+  end
+  highlight.create_highlight_groups(config.options.theme)
   vim.api.nvim_exec([[
   augroup lualine
   autocmd!
-  autocmd ColorScheme * call v:lua.lualine_set_theme()
+  autocmd ColorScheme * lua require'lualine.utils.utils'.reload_highlights()
   augroup END
   ]], false)
 end

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -68,11 +68,9 @@ local function load_special_components(component)
       -- filters g portion from g:var
       local scope = component:match('[gvtwb]?o?')
       -- filters var portion from g:var
-      -- For some reason overwriting component var from outer scope causes the
-      -- component not to work . So creating a new local name component to use:/
-      local component = component:sub(#scope + 2, #component)
+      local var_name = component:sub(#scope + 2, #component)
       -- Displays nothing when veriable aren't present
-      local return_val = vim[scope][component]
+      local return_val = vim[scope][var_name]
       if return_val == nil then return '' end
       local ok
       ok, return_val = pcall(tostring, return_val)

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -2,17 +2,6 @@
 -- MIT license, see LICENSE for more details.
 local M = {}
 
--- Works as a decorator to expand set_lualine_theme functions
--- functionality at runtime .
-function M.expand_set_theme(func)
-  -- execute a local version of global function to not get in a inf recurtion
-  local set_theme = _G.lualine_set_theme
-  _G.lualine_set_theme = function()
-    set_theme()
-    func()
-  end
-end
-
 -- Note for now only works for termguicolors scope can be background or foreground
 function M.extract_highlight_colors(color_group, scope)
   if vim.fn.hlexists(color_group) == 0 then return nil end
@@ -41,15 +30,14 @@ end
 M.loaded_highlights = {}
 
 -- sets loaded_highlights table
-function M.save_highlight(highlight_name)
-  M.loaded_highlights[highlight_name] = true
+function M.save_highlight(highlight_name, highlight_args)
+  M.loaded_highlights[highlight_name] = highlight_args
 end
 
--- clears loaded_highlights table and highlights
-function M.clear_highlights()
-  for highlight_name, _ in pairs(M.loaded_highlights) do
-    vim.cmd('highlight clear ' .. highlight_name)
-    M.loaded_highlights[highlight_name] = nil
+function M.reload_highlights()
+  local highlight = require('lualine.highlight')
+  for _, highlight_args in pairs(M.loaded_highlights) do
+     highlight.highlight(unpack(highlight_args))
   end
 end
 


### PR DESCRIPTION
- Previously custom highlights/component highlights had to callexpand_set_theme to make them restored . That's unintuative . Now any highlight created by lualine.highlight.highlight() will be restored :)
- Renamed component -> var_name in special variable component | Proper BugFix