### PR TITLE
docs: add spaceduck.lua to themes

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -162,6 +162,12 @@ lualine try to match your colorscheme.
 ![solarizedlightvisual_cropped](https://user-images.githubusercontent.com/41551030/108649255-475f4900-74bd-11eb-8a75-7ca266d56009.png)
 ![solarizedlightreplace_cropped](https://user-images.githubusercontent.com/41551030/108649258-48907600-74bd-11eb-9bba-8e82b56777d9.png)
 
+### spaceduck
+![spaceducknormal_cropped](https://user-images.githubusercontent.com/32819563/111934957-16f0d780-8a88-11eb-9f33-f02c9ba364c1.png)
+![spaceduckinsert_cropped](https://user-images.githubusercontent.com/32819563/111934981-21ab6c80-8a88-11eb-8118-dfbc2dc3bddf.png)
+![spaceduckvisual_cropped](https://user-images.githubusercontent.com/32819563/111935019-325be280-8a88-11eb-9846-a2d7bfec226c.png)
+![spaceduckreplace_cropped](https://user-images.githubusercontent.com/32819563/111935037-3ab41d80-8a88-11eb-8797-2b6db14cbff8.png)
+
 ### tomorrow
 ![tomorrownormal_cropped](https://user-images.githubusercontent.com/41551030/108649275-51814780-74bd-11eb-881b-1e137a0cbfe0.png)
 ![tomorrowinsert_cropped](https://user-images.githubusercontent.com/41551030/108649297-59d98280-74bd-11eb-92a5-a8c4af150106.png)

--- a/lua/lualine/themes/spaceduck.lua
+++ b/lua/lualine/themes/spaceduck.lua
@@ -1,0 +1,58 @@
+local spaceduck = {}
+
+local colors = {
+  black = '#0f111b',
+  white = '#ecf0c1',
+  red = '#e33400',
+  green = '#5ccc96',
+  blue = '#00a3cc',
+  purple = '#7a5ccc',
+  yellow = '#f2ce00',
+  gray = '#686f9a',
+  darkgray = '#30365F',
+  lightgray = '#c1c3cc'
+}
+
+spaceduck.normal = {
+  -- gui parameter is optional and behaves the same way as in vim's highlight command
+  a = {bg = colors.gray, fg = colors.black, gui = 'bold'},
+  b = {bg = colors.darkgray, fg = colors.lightgray},
+  c = {bg = colors.black, fg = colors.lightgray}
+}
+
+spaceduck.insert = {
+  a = {bg = colors.green, fg = colors.black, gui = 'bold'},
+  b = {bg = colors.darkgray, fg = colors.lightgray},
+  c = {bg = colors.black, fg = colors.lightgray}
+}
+
+spaceduck.visual = {
+  a = {bg = colors.yellow, fg = colors.black, gui = 'bold'},
+  b = {bg = colors.darkgray, fg = colors.lightgray},
+  c = {bg = colors.black, fg = colors.lightgray}
+}
+
+spaceduck.replace = {
+  a = {bg = colors.purple, fg = colors.black, gui = 'bold'},
+  b = {bg = colors.darkgray, fg = colors.lightgray},
+  c = {bg = colors.black, fg = colors.lightgray}
+}
+
+spaceduck.command = {
+  a = {bg = colors.blue, fg = colors.black, gui = 'bold'},
+  b = {bg = colors.darkgray, fg = colors.lightgray},
+  c = {bg = colors.black, fg = colors.lightgray}
+}
+
+-- you can assign one colorscheme to another, if a colorscheme is
+-- undefined it falls back to normal
+spaceduck.terminal = spaceduck.normal
+
+spaceduck.inactive = {
+  a = {bg = colors.black, fg = colors.lightgray, gui = 'bold'},
+  b = {bg = colors.black, fg = colors.lightgray},
+  c = {bg = colors.black, fg = colors.lightgray}
+}
+
+-- lualine.theme = spaceduck
+return spaceduck


### PR DESCRIPTION
Hey this is my first official pull request, so hopefully I did everything right.

I made the [ vim spaceduck colorscheme](https://github.com/pineapplegiant/spaceduck), and I really like your plugin so hopefully this works so others can use it. I ran the `lua-format` using your config, like you suggested, and just copied gruvbox's theme as a starter template to making the theme. Let me know if I should make any changes.

Cheers 🍻 