### PR TITLE
Enhance theme

### DIFF
--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -72,19 +72,17 @@ local function diagnostics(options)
   if options.colored == nil then options.colored = true end
   -- apply colors
   if not options.color_error then
-    options.color_error = utils.extract_highlight_colors('DiffDelete',
-                                                         'guifg') or
-                              default_color_error
+    options.color_error =
+        utils.extract_highlight_colors('DiffDelete', 'guifg') or
+            default_color_error
   end
   if not options.color_warn then
-    options.color_warn =
-        utils.extract_highlight_colors('DiffText', 'guifg') or
-            default_color_warn
+    options.color_warn = utils.extract_highlight_colors('DiffText', 'guifg') or
+                             default_color_warn
   end
   if not options.color_info then
-    options.color_info =
-        utils.extract_highlight_colors('Normal', 'guifg') or
-            default_color_info
+    options.color_info = utils.extract_highlight_colors('Normal', 'guifg') or
+                             default_color_info
   end
 
   local highlight_groups = {}

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -4,6 +4,7 @@ local M = {}
 local utils_colors = require 'lualine.utils.cterm_colors'
 local utils = require 'lualine.utils.utils'
 local section_highlight_map = {x = 'c', y = 'b', z = 'a'}
+local active_theme = nil
 
 function M.highlight(name, foreground, background, gui, reload)
   local command = {'highlight', name}
@@ -26,6 +27,8 @@ function M.highlight(name, foreground, background, gui, reload)
 end
 
 function M.create_highlight_groups(theme)
+  utils.clear_highlights()
+  active_theme = theme
   for mode, sections in pairs(theme) do
     for section, colorscheme in pairs(sections) do
       local highlight_group_name = {'lualine', section, mode}
@@ -59,13 +62,12 @@ local function append_mode(highlight_group)
 end
 
 -- Create highlight group with fg bg and gui from theme
--- section and theme are extracted from @options.self table
--- @@color has to be { fg = "#rrggbb", bg="#rrggbb" gui = "effect" }
+-- @color has to be { fg = "#rrggbb", bg="#rrggbb" gui = "effect" }
 -- all the color elements are optional if fg or bg is not given options must be provided
 -- So fg and bg can default the themes colors
--- @@highlight_tag is unique tag for highlight group
+-- @highlight_tag is unique tag for highlight group
 -- returns the name of highlight group
--- @@options is parameter of component.init() function
+-- @options is parameter of component.init() function
 -- @return: (string) unique name that can be used by component_format_highlight
 --   to retrive highlight group
 function M.create_component_highlight_group(color, highlight_tag, options)
@@ -87,9 +89,9 @@ function M.create_component_highlight_group(color, highlight_tag, options)
   if section > 'c' then section = section_highlight_map[section] end
   for _, mode in ipairs(modes) do
     local highlight_group_name = {options.self.section, highlight_tag, mode}
-    local default_color_table = options.theme[mode] and
-                                    options.theme[mode][section] or
-                                    options.theme.normal[section]
+    local default_color_table = active_theme[mode] and
+                                    active_theme[mode][section] or
+                                    active_theme.normal[section]
     local bg = (color.bg or default_color_table.bg)
     local fg = (color.fg or default_color_table.fg)
     -- Check if it's same as normal mode if it is no need to create aditional highlight

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -33,7 +33,7 @@ function M.create_highlight_groups(theme)
     for section, colorscheme in pairs(sections) do
       local highlight_group_name = {'lualine', section, mode}
       M.highlight(table.concat(highlight_group_name, '_'), colorscheme.fg,
-                colorscheme.bg, colorscheme.gui)
+                  colorscheme.bg, colorscheme.gui)
     end
   end
 end

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -272,8 +272,13 @@ local function setup_theme()
     local ok
     ok, theme = pcall(require, 'lualine.themes.' .. theme_name)
     if not ok then
-      vim.api.nvim_echo({{'theme ' .. theme_name .. ' not found defaulting to gruvbox', 'ErrorMsg'}}, true, {})
-      theme = require'lualine.themes.gruvbox'
+      vim.api.nvim_echo({
+        {
+          'theme ' .. theme_name .. ' not found defaulting to gruvbox',
+          'ErrorMsg'
+        }
+      }, true, {})
+      theme = require 'lualine.themes.gruvbox'
     end
   end
   highlight.create_highlight_groups(theme)

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -267,9 +267,8 @@ local function tabline() return statusline(config.tabline, true) end
 
 local function setup_theme()
   local theme_name = config.options.theme
-  local theme
+  local ok, theme
   if type(theme_name) == 'string' then
-    local ok
     ok, theme = pcall(require, 'lualine.themes.' .. theme_name)
     if not ok then
       vim.api.nvim_echo({

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -266,9 +266,15 @@ end
 local function tabline() return statusline(config.tabline, true) end
 
 local function setup_theme()
-  local theme = config.options.theme
-  if type(theme) == 'string' then
-    theme = require('lualine.themes.' .. theme)
+  local theme_name = config.options.theme
+  local theme
+  if type(theme_name) == 'string' then
+    local ok
+    ok, theme = pcall(require, 'lualine.themes.' .. theme_name)
+    if not ok then
+      vim.api.nvim_echo({{'theme ' .. theme_name .. ' not found defaulting to gruvbox', 'ErrorMsg'}}, true, {})
+      theme = require'lualine.themes.gruvbox'
+    end
   end
   highlight.create_highlight_groups(theme)
   vim.api.nvim_exec([[

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -266,10 +266,11 @@ end
 local function tabline() return statusline(config.tabline, true) end
 
 local function setup_theme()
-  if type(config.options.theme) == 'string' then
-    config.options.theme = require('lualine.themes.' .. config.options.theme)
+  local theme = config.options.theme
+  if type(theme) == 'string' then
+    theme = require('lualine.themes.' .. theme)
   end
-  highlight.create_highlight_groups(config.options.theme)
+  highlight.create_highlight_groups(theme)
   vim.api.nvim_exec([[
   augroup lualine
   autocmd!

--- a/lua/lualine/utils/section.lua
+++ b/lua/lualine/utils/section.lua
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
 local utils_component = require('lualine.utils.component')
-local M ={}
+local M = {}
 -- Returns formated string for a section
 function M.draw_section(section, highlight_name)
   local status = {}
@@ -16,7 +16,8 @@ function M.draw_section(section, highlight_name)
       localstatus = utils_component.apply_icon(localstatus, component)
       localstatus = utils_component.apply_case(localstatus, component)
       localstatus = utils_component.apply_padding(localstatus, component)
-      localstatus = utils_component.apply_highlights(localstatus, component, highlight_name)
+      localstatus = utils_component.apply_highlights(localstatus, component,
+                                                     highlight_name)
       localstatus = utils_component.apply_spearator(localstatus, component)
       if custom_highlight_at_begining or (#drawn_components > 0 and
           not drawn_components[#drawn_components].separator_applied) then
@@ -35,13 +36,16 @@ function M.draw_section(section, highlight_name)
   for i = 1, #status do
     if (drawn_components[i].color and drawn_components[i].color.bg) or
         drawn_components[i].custom_highlight then
-      status[i] = utils_component.strip_separator(status[i], drawn_components[i])
+      status[i] =
+          utils_component.strip_separator(status[i], drawn_components[i])
       if i > 1 then
-        status[i - 1] = utils_component.strip_separator(status[i - 1], drawn_components[i - 1])
+        status[i - 1] = utils_component.strip_separator(status[i - 1],
+                                                        drawn_components[i - 1])
       end
     end
   end
-  status[#status] = utils_component.strip_separator(status[#status], drawn_components[#status])
+  status[#status] = utils_component.strip_separator(status[#status],
+                                                    drawn_components[#status])
   return table.concat(status)
 end
 

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -37,7 +37,7 @@ end
 function M.reload_highlights()
   local highlight = require('lualine.highlight')
   for _, highlight_args in pairs(M.loaded_highlights) do
-     highlight.highlight(unpack(highlight_args))
+    highlight.highlight(unpack(highlight_args))
   end
 end
 

--- a/lua/lualine/utils/utils.lua
+++ b/lua/lualine/utils/utils.lua
@@ -46,4 +46,12 @@ function M.highlight_exists(highlight_name)
   return M.loaded_highlights[highlight_name] and true or false
 end
 
+-- clears loaded_highlights table and highlights
+function M.clear_highlights()
+  for highlight_name, _ in pairs(M.loaded_highlights) do
+    vim.cmd('highlight clear ' .. highlight_name)
+    M.loaded_highlights[highlight_name] = nil
+  end
+end
+
 return M


### PR DESCRIPTION
Changes:
- loaded theme table is nolonger stored in 
  configs and thus not passed
  to components. Insted it's cached in highlights.lua
- Reintroducing clear_highlights turns out themes can still change if
  setup is called more than once
- Now lualine doesn't crash from invalid theme name

These changes are actually better out of #141 luckily cherry-pick went easy on me this time .
There's one more line of highlight change that I would like to bring here but int's too deep . I might look into it later if #141 isn't merged by then :)