### PR TITLE
Fix: Restore support for dictionary-typed theme setup parameter

### DIFF
--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -279,6 +279,8 @@ local function setup_theme()
       }, true, {})
       theme = require 'lualine.themes.gruvbox'
     end
+  else
+    theme = config.options.theme
   end
   highlight.create_highlight_groups(theme)
   vim.api.nvim_exec([[

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -280,6 +280,7 @@ local function setup_theme()
       theme = require 'lualine.themes.gruvbox'
     end
   else
+    -- use the provided theme as-is, assuming it's a dictionary
     theme = config.options.theme
   end
   highlight.create_highlight_groups(theme)


### PR DESCRIPTION
This was the original behaviour before 37a3b8c, using the provided `config.options.theme` as a dictionary to build highlight groups unless it's a string.