### PR TITLE
BugFix: fix vim functions displaying nil

### DIFF
--- a/lua/lualine/components/special/eval_func_component.lua
+++ b/lua/lualine/components/special/eval_func_component.lua
@@ -3,7 +3,9 @@ local EvalFuncComponent = require('lualine.component'):new()
 EvalFuncComponent.update_status = function(self)
   local component = self.options[1]
   local ok, status = pcall(EvalFuncComponent.eval_lua, component)
-  if not ok then status = EvalFuncComponent.vim_function(component) end
+  if not ok or status == 'nil' then
+    status = EvalFuncComponent.vim_function(component)
+  end
   return status
 end
 


### PR DESCRIPTION
nil check was unintentionally removed in 77c4c4748254cd6087c6cc1e8be72485d278eb48