### PR TITLE
Fix: Transitional highlight not found error

### DIFF
--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -203,11 +203,10 @@ function M.get_transitional_highlights(left_section_data, right_section_data,
     -- using string.format to convert decimal to hexadecimal
     local fg = utils.extract_highlight_colors(left_highlight_name, 'bg')
     local bg = utils.extract_highlight_colors(right_highlight_name, 'bg')
-    if not fg then fg = 'none' end
-    if not bg then bg = 'none' end
     -- swap the bg and fg when reverse is true. As in that case highlight will
     -- be placed before section
     if reverse then fg, bg = bg, fg end
+    if not fg or not bg then return '' end -- Color retrieval failed
     M.highlight(highlight_name, fg, bg)
   end
   return '%#' .. highlight_name .. '#'

--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -152,7 +152,7 @@ local function statusline(sections, is_focused)
       local current_section = status_builder[i]
       local next_section = status_builder[i + 1] or {}
       -- For 2nd half we need to show separator before section
-      if current_section.name > 'x' then
+      if current_section.name > 'x' and config.options.section_separators[2] ~= '' then
         local transitional_highlight = highlight.get_transitional_highlights(
                                            previous_section.data,
                                            current_section.data, true)
@@ -167,7 +167,7 @@ local function statusline(sections, is_focused)
       table.insert(status, status_builder[i].data)
 
       -- For 1st half we need to show separator after section
-      if current_section.name < 'c' then
+      if current_section.name < 'c' and config.options.section_separators[1] ~= ''  then
         local transitional_highlight = highlight.get_transitional_highlights(
                                            current_section.data,
                                            next_section.data)

--- a/lua/lualine/utils/section.lua
+++ b/lua/lualine/utils/section.lua
@@ -39,7 +39,7 @@ function M.draw_section(section, highlight_name)
   -- Remove empty strings from status
   status = utils.list_shrink(status)
   local status_str = table.concat(status)
-  if status_str:find('%%#.*#') == 1 then
+  if status_str:find('%%#.*#') == 1 or #status_str == 0 then
     -- Don't prepend with old highlight when the component changes it imidiately
     return status_str
   else


### PR DESCRIPTION
Changes:
- transitional_highlight isn't created when both retrieval of fg or bg
  has failed
- Transitional highlight is not looked for when section separators are
  disabled
- empty section no longer returns highlight group as section data

It possibly resolves #193 .