### PR TITLE
Fix workflows running twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: Tests
 
 on: 
   push:
-    branches-ignore: [master]
+    branches: [master]
   pull_request:
-    types: [opened, reopened]
 
 jobs:
   appimage-ubuntu:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,8 @@ name: Linting
 
 on: 
   push:
-    branches-ignore: [master]
+    branches: [master]
   pull_request:
-    types: [opened, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
I think what we need is this .

I tested at on my fork . https://github.com/shadmansaleh/lualine.nvim/pull/1

Runs tests when pr is opened , when following commits are pushed to the pr and when pr is merged (check mark in the logs is nice :] )

checkout my fork .

Most of the workflows I've checked are directly using on : [push, pull_request] . We can isolate the push event to master branch only . So if another branch is created in main repo pushing to it won't trigger workflow . But if that branch has a pull request it will .