### PR TITLE
enhancement: show diff when component is loaded

### DIFF
--- a/lua/lualine/components/diff.lua
+++ b/lua/lualine/components/diff.lua
@@ -62,6 +62,10 @@ Diff.new = function(self, options, child)
     }
   end
 
+  -- call update functions so git diff is present when component is loaded
+  Diff.update_git_diff_getter()
+  Diff.update_git_diff()
+
   vim.api.nvim_exec([[
   autocmd lualine BufEnter     * lua require'lualine.components.diff'.update_git_diff_getter()
   autocmd lualine BufEnter     * lua require'lualine.components.diff'.update_git_diff()


### PR DESCRIPTION
This makes the diff component present when initialized. Currently, when opening a file on startup, the component only appears once the `BufEnter` autocmd's are executed.