### PR TITLE
Allow x,y,z section to be themed independenly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,11 @@ lualine theme at lua/lualine/themes/{your_colorscheme}.lua in you repo.
 To create a custom theme you need to define a colorscheme for each of vim's modes. Each mode has a `fg` and `bg` field for every lualine section.
 You can add special effects with `gui`.
 
-Adding theme is really easy in lua. Here is and example of a gruvbox theme.
+Though the example shows a,b,c being set you can specify theme for x, y, z too.
+But if unspecified then they default to c, b, a sections theme respectively .
+ Also all modes theme defaults to normal modes theme.
 
+Adding theme is really easy in lua. Here is and example of a gruvbox theme.
 ```lua
 local gruvbox = {  }
 

--- a/lua/lualine/highlight.lua
+++ b/lua/lualine/highlight.lua
@@ -95,7 +95,8 @@ function M.create_component_highlight_group(color, highlight_tag, options)
   local normal_hl
   -- convert lualine_a -> a before setting section
   local section = options.self.section:match('lualine_(.*)')
-  if section > 'c' then section = section_highlight_map[section] end
+  if section > 'c' and not active_theme.normal[section] then
+    section = section_highlight_map[section] end
   for _, mode in ipairs(modes) do
     local highlight_group_name = {options.self.section, highlight_tag, mode}
     local default_color_table = active_theme[mode] and
@@ -139,7 +140,8 @@ function M.component_format_highlight(highlight_name)
 end
 
 function M.format_highlight(is_focused, highlight_group)
-  if highlight_group > 'lualine_c' then
+  if highlight_group > 'lualine_c'
+    and not utils.highlight_exists(highlight_group .. '_normal') then
     highlight_group = 'lualine_' ..
                           section_highlight_map[highlight_group:match(
                               'lualine_(.)')]


### PR DESCRIPTION
If theme for x,y,z is unspecified the default to c,b,a respectively

Follow up on #31 
resonable solution to #227

The refractors I did to highlighter made it simple to allow this . So just flipping the switch here :)

@hoob3rt I think we should allow this . This is 100% backword compatable and absolutly optional . But makes asymatric themeing easily possible . 
