### PR TITLE
Quickfix extension: label for location list

### DIFF
--- a/lua/lualine/extensions/quickfix.lua
+++ b/lua/lualine/extensions/quickfix.lua
@@ -1,14 +1,26 @@
 -- Copyright (c) 2020-2021 hoob3rt
 -- MIT license, see LICENSE for more details.
-local function quickfix() return 'Quickfix List' end
+--
+local function is_loclist()
+  return vim.fn.getloclist(0, {filewinid = 1}).filewinid ~= 0
+end
 
-local function quickfix_title() return vim.fn.getqflist({title = 0}).title end
+local function label()
+  return is_loclist() and 'Location List' or 'Quickfix List'
+end
+
+local function title()
+  if is_loclist() then
+    return vim.fn.getloclist(0, {title = 0}).title
+  end
+  return vim.fn.getqflist({title = 0}).title
+end
 
 local M = {}
 
 M.sections = {
-  lualine_a = {quickfix},
-  lualine_b = {quickfix_title},
+  lualine_a = {label},
+  lualine_b = {title},
   lualine_z = {'location'}
 }
 


### PR DESCRIPTION
Adds a separate label for locations lists than for quickfix lists. The logic is a bit roundabout, but I don't know of any better way to tell the difference between the two list types.