### PR TITLE
fix: estimate_space_available must include window width

### DIFF
--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -44,7 +44,7 @@ FileName.update_status = function(self)
   if data == '' then data = '[No Name]' end
 
   local windwidth = vim.fn.winwidth(0)
-  local estimated_space_available = 40
+  local estimated_space_available = windwidth - 40
   local path_separator = package.config:sub(1, 1)
   for _ = 0, count(data, path_separator) do
     if windwidth <= 84 or #data > estimated_space_available then


### PR DESCRIPTION
Resolves: https://github.com/hoob3rt/lualine.nvim/pull/224#issuecomment-850633672

the estimated_space_available _must_ subtract from the window width. The 40 value is the estimated amount of space decorated on either side (combined).


Before: Top: absolute, bottom: relative

![image](https://user-images.githubusercontent.com/199018/120035098-08fd8c80-bfcc-11eb-8404-36d17daacef7.png)

![image](https://user-images.githubusercontent.com/199018/120035078-0438d880-bfcc-11eb-8f7b-e414d0e487ed.png)


After: Top: absolute, bottom: relative
![image](https://user-images.githubusercontent.com/199018/120035014-e9666400-bfcb-11eb-96d6-c064d0969137.png)

