### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ local custom_gruvbox = require'lualine.themes.gruvbox'
 -- Change the background of lualine_c section for normal mode
 custom_gruvbox.normal.c.bg = '#112233' -- rgb colors are supported
 require'lualine'.setup{
-  options = { theme  = custom_gruvbox },
+  options = { theme  = 'custom_gruvbox' },
   ...
 }
 ```


### PR DESCRIPTION
i was looking at the instructions in the customizing themes section, and the colorscheme (solarized_dark in this case) didn't load until i put quotes around it there. im not sure if its always required, but it was in my case, so perhaps it should be fixed in the readme