### PR TITLE
Add ability to set fg and bg colors to diagnostics section

### DIFF
--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -7,11 +7,10 @@ local Diagnostics = require('lualine.component'):new()
 
 -- LuaFormatter off
 Diagnostics.default_colors = {
-  error = '#000000',
-  error_bg = '#e06c75',
-  warn  = '#ffdf00',
-  info  = '#ffffff',
-  hint  = '#d7afaf',
+  error = { fg = '#000000', bg = '#e06c75' },
+  warn = { fg = '#000000', bg = '#ffdf00' },
+  info = { fg = '#000000', bg = '#ffffff' },
+  hint = { fg = '#000000', bg = '#d7afaf' }
 }
 -- LuaFormatter on
 
@@ -37,49 +36,67 @@ Diagnostics.new = function(self, options, child)
     new_diagnostics.options.colored = true
   end
   -- apply colors
-  if not new_diagnostics.options.color_error then
-    new_diagnostics.options.color_error =
+  if not new_diagnostics.options.color_error.fg then
+    new_diagnostics.options.color_error.fg =
         utils.extract_highlight_colors('LspDiagnosticsDefaultError', 'fg') or
             utils.extract_highlight_colors('DiffDelete', 'fg') or
-            Diagnostics.default_colors.error
+            Diagnostics.default_colors.error.fg
   end
-  if not new_diagnostics.options.color_error_bg then
-    new_diagnostics.options.color_error_bg =
+  if not new_diagnostics.options.color_error.bg then
+    new_diagnostics.options.color_error.bg =
         utils.extract_highlight_colors('LspDiagnosticsDefaultErrorBg', 'bg') or
-        Diagnostics.default_colors.error_bg
+        Diagnostics.default_colors.error.bg
   end
-  if not new_diagnostics.options.color_warn then
-    new_diagnostics.options.color_warn =
+  if not new_diagnostics.options.color_warn.fg then
+    new_diagnostics.options.color_warn.fg =
         utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
             utils.extract_highlight_colors('DiffText', 'fg') or
-            Diagnostics.default_colors.warn
+            Diagnostics.default_colors.warn.fg
   end
-  if not new_diagnostics.options.color_info then
-    new_diagnostics.options.color_info =
+  if not new_diagnostics.options.color_warn.bg then
+    new_diagnostics.options.color_warn.bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultWarningBg', 'bg') or
+            utils.extract_highlight_colors('DiffText', 'bg') or
+            Diagnostics.default_colors.warn.bg
+  end
+  if not new_diagnostics.options.color_info.fg then
+    new_diagnostics.options.color_info.fg =
         utils.extract_highlight_colors('LspDiagnosticsDefaultInformation', 'fg') or
             utils.extract_highlight_colors('Normal', 'fg') or
-            Diagnostics.default_colors.info
+            Diagnostics.default_colors.info.fg
   end
-  if not new_diagnostics.options.color_hint then
-    new_diagnostics.options.color_hint =
+  if not new_diagnostics.options.color_info.bg then
+    new_diagnostics.options.color_info.bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultInformationBg', 'bg') or
+            utils.extract_highlight_colors('Normal', 'bg') or
+            Diagnostics.default_colors.info.bg
+  end
+  if not new_diagnostics.options.color_hint.fg then
+    new_diagnostics.options.color_hint.fg =
         utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'fg') or
             utils.extract_highlight_colors('DiffChange', 'fg') or
-            Diagnostics.default_colors.hint
+            Diagnostics.default_colors.hint.fg
+  end
+  if not new_diagnostics.options.color_hint.bg then
+    new_diagnostics.options.color_hint.bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'bg') or
+            utils.extract_highlight_colors('DiffChange', 'bg') or
+            Diagnostics.default_colors.hint.bg
   end
 
   if new_diagnostics.options.colored then
     new_diagnostics.highlight_groups = {
       error = highlight.create_component_highlight_group(
-          {fg = new_diagnostics.options.color_error, bg = new_diagnostics.options.color_error_bg}, 'diagnostics_error',
+          {fg = new_diagnostics.options.color_error.fg, bg = new_diagnostics.options.color_error.bg}, 'diagnostics_error',
           new_diagnostics.options),
       warn = highlight.create_component_highlight_group(
-          {fg = new_diagnostics.options.color_warn}, 'diagnostics_warn',
+          {fg = new_diagnostics.options.color_warn.fg, bg = new_diagnostics.options.color_warn.bg}, 'diagnostics_warn',
           new_diagnostics.options),
       info = highlight.create_component_highlight_group(
-          {fg = new_diagnostics.options.color_info}, 'diagnostics_info',
+          {fg = new_diagnostics.options.color_info.fg, bg = new_diagnostics.options.color_info.bg}, 'diagnostics_info',
           new_diagnostics.options),
       hint = highlight.create_component_highlight_group(
-          {fg = new_diagnostics.options.color_hint}, 'diagnostics_hint',
+          {fg = new_diagnostics.options.color_hint.fg, bg = new_diagnostics.options.color_hint.bg}, 'diagnostics_hint',
           new_diagnostics.options)
     }
   end

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -36,52 +36,60 @@ Diagnostics.new = function(self, options, child)
     new_diagnostics.options.colored = true
   end
   -- apply colors
-  if not new_diagnostics.options.color_error.fg then
-    new_diagnostics.options.color_error.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultError', 'fg') or
-            utils.extract_highlight_colors('DiffDelete', 'fg') or
-            Diagnostics.default_colors.error.fg
+  if not new_diagnostics.options.color_error then
+    if not new_diagnostics.options.color_error.fg then
+      new_diagnostics.options.color_error.fg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultError', 'fg') or
+              utils.extract_highlight_colors('DiffDelete', 'fg') or
+              Diagnostics.default_colors.error.fg
+    end
+    if not new_diagnostics.options.color_error.bg then
+      new_diagnostics.options.color_error.bg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultErrorBg', 'bg') or
+          Diagnostics.default_colors.error.bg
+    end
   end
-  if not new_diagnostics.options.color_error.bg then
-    new_diagnostics.options.color_error.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultErrorBg', 'bg') or
-        Diagnostics.default_colors.error.bg
+  if not new_diagnostics.options.color_warn then
+    if not new_diagnostics.options.color_warn.fg then
+      new_diagnostics.options.color_warn.fg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
+              utils.extract_highlight_colors('DiffText', 'fg') or
+              Diagnostics.default_colors.warn.fg
+    end
+    if not new_diagnostics.options.color_warn.bg then
+      new_diagnostics.options.color_warn.bg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultWarningBg', 'bg') or
+              utils.extract_highlight_colors('DiffText', 'bg') or
+              Diagnostics.default_colors.warn.bg
+    end
   end
-  if not new_diagnostics.options.color_warn.fg then
-    new_diagnostics.options.color_warn.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
-            utils.extract_highlight_colors('DiffText', 'fg') or
-            Diagnostics.default_colors.warn.fg
+  if not new_diagnostics.options.color_info then
+    if not new_diagnostics.options.color_info.fg then
+      new_diagnostics.options.color_info.fg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultInformation', 'fg') or
+              utils.extract_highlight_colors('Normal', 'fg') or
+              Diagnostics.default_colors.info.fg
+    end
+    if not new_diagnostics.options.color_info.bg then
+      new_diagnostics.options.color_info.bg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultInformationBg', 'bg') or
+              utils.extract_highlight_colors('Normal', 'bg') or
+              Diagnostics.default_colors.info.bg
+    end
   end
-  if not new_diagnostics.options.color_warn.bg then
-    new_diagnostics.options.color_warn.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultWarningBg', 'bg') or
-            utils.extract_highlight_colors('DiffText', 'bg') or
-            Diagnostics.default_colors.warn.bg
-  end
-  if not new_diagnostics.options.color_info.fg then
-    new_diagnostics.options.color_info.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultInformation', 'fg') or
-            utils.extract_highlight_colors('Normal', 'fg') or
-            Diagnostics.default_colors.info.fg
-  end
-  if not new_diagnostics.options.color_info.bg then
-    new_diagnostics.options.color_info.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultInformationBg', 'bg') or
-            utils.extract_highlight_colors('Normal', 'bg') or
-            Diagnostics.default_colors.info.bg
-  end
-  if not new_diagnostics.options.color_hint.fg then
-    new_diagnostics.options.color_hint.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'fg') or
-            utils.extract_highlight_colors('DiffChange', 'fg') or
-            Diagnostics.default_colors.hint.fg
-  end
-  if not new_diagnostics.options.color_hint.bg then
-    new_diagnostics.options.color_hint.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'bg') or
-            utils.extract_highlight_colors('DiffChange', 'bg') or
-            Diagnostics.default_colors.hint.bg
+  if not new_diagnostics.options.color_hint then
+    if not new_diagnostics.options.color_hint.fg then
+      new_diagnostics.options.color_hint.fg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'fg') or
+              utils.extract_highlight_colors('DiffChange', 'fg') or
+              Diagnostics.default_colors.hint.fg
+    end
+    if not new_diagnostics.options.color_hint.bg then
+      new_diagnostics.options.color_hint.bg =
+          utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'bg') or
+              utils.extract_highlight_colors('DiffChange', 'bg') or
+              Diagnostics.default_colors.hint.bg
+    end
   end
 
   if new_diagnostics.options.colored then

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -38,54 +38,43 @@ Diagnostics.new = function(self, options, child)
   -- apply colors
   if not new_diagnostics.options.color_error then new_diagnostics.options.color_error = {} end
   if not new_diagnostics.options.color_error.fg then
-    new_diagnostics.options.color_error.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultError', 'fg') or
-            utils.extract_highlight_colors('DiffDelete', 'fg') or
-            Diagnostics.default_colors.error.fg
+    new_diagnostics.options.color_error.fg = Diagnostics.default_colors.error.fg
   end
   if not new_diagnostics.options.color_error.bg then
     new_diagnostics.options.color_error.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultErrorBg', 'bg') or
+        utils.extract_highlight_colors('LspDiagnosticsDefaultError', 'fg') or
+        utils.extract_highlight_colors('DiffDelete', 'fg') or
         Diagnostics.default_colors.error.bg
   end
   if not new_diagnostics.options.color_warn then new_diagnostics.options.color_warn = {} end
   if not new_diagnostics.options.color_warn.fg then
-    new_diagnostics.options.color_warn.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
-            utils.extract_highlight_colors('DiffText', 'fg') or
-            Diagnostics.default_colors.warn.fg
+    new_diagnostics.options.color_warn.fg = Diagnostics.default_colors.warn.fg
   end
   if not new_diagnostics.options.color_warn.bg then
     new_diagnostics.options.color_warn.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultWarningBg', 'bg') or
-            utils.extract_highlight_colors('DiffText', 'bg') or
-            Diagnostics.default_colors.warn.bg
+        utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
+        utils.extract_highlight_colors('DiffText', 'fg') or
+        Diagnostics.default_colors.warn.bg
   end
   if not new_diagnostics.options.color_info then new_diagnostics.options.color_info = {} end
   if not new_diagnostics.options.color_info.fg then
-    new_diagnostics.options.color_info.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultInformation', 'fg') or
-            utils.extract_highlight_colors('Normal', 'fg') or
-            Diagnostics.default_colors.info.fg
+    new_diagnostics.options.color_info.fg = Diagnostics.default_colors.info.fg
   end
   if not new_diagnostics.options.color_info.bg then
     new_diagnostics.options.color_info.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultInformationBg', 'bg') or
-            utils.extract_highlight_colors('Normal', 'bg') or
-            Diagnostics.default_colors.info.bg
+        utils.extract_highlight_colors('LspDiagnosticsDefaultInformation', 'fg') or
+        utils.extract_highlight_colors('Normal', 'fg') or
+        Diagnostics.default_colors.info.bg
   end
   if not new_diagnostics.options.color_hint then new_diagnostics.options.color_hint = {} end
   if not new_diagnostics.options.color_hint.fg then
-    new_diagnostics.options.color_hint.fg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'fg') or
-            utils.extract_highlight_colors('DiffChange', 'fg') or
-            Diagnostics.default_colors.hint.fg
+    new_diagnostics.options.color_hint.fg = Diagnostics.default_colors.hint.fg
   end
   if not new_diagnostics.options.color_hint.bg then
     new_diagnostics.options.color_hint.bg =
-        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'bg') or
-            utils.extract_highlight_colors('DiffChange', 'bg') or
-            Diagnostics.default_colors.hint.bg
+        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'fg') or
+        utils.extract_highlight_colors('DiffChange', 'fg') or
+        Diagnostics.default_colors.hint.bg
   end
 
   if new_diagnostics.options.colored then

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -36,60 +36,56 @@ Diagnostics.new = function(self, options, child)
     new_diagnostics.options.colored = true
   end
   -- apply colors
-  if not new_diagnostics.options.color_error then
-    if not new_diagnostics.options.color_error.fg then
-      new_diagnostics.options.color_error.fg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultError', 'fg') or
-              utils.extract_highlight_colors('DiffDelete', 'fg') or
-              Diagnostics.default_colors.error.fg
-    end
-    if not new_diagnostics.options.color_error.bg then
-      new_diagnostics.options.color_error.bg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultErrorBg', 'bg') or
-          Diagnostics.default_colors.error.bg
-    end
+  if not new_diagnostics.options.color_error then new_diagnostics.options.color_error = {} end
+  if not new_diagnostics.options.color_error.fg then
+    new_diagnostics.options.color_error.fg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultError', 'fg') or
+            utils.extract_highlight_colors('DiffDelete', 'fg') or
+            Diagnostics.default_colors.error.fg
   end
-  if not new_diagnostics.options.color_warn then
-    if not new_diagnostics.options.color_warn.fg then
-      new_diagnostics.options.color_warn.fg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
-              utils.extract_highlight_colors('DiffText', 'fg') or
-              Diagnostics.default_colors.warn.fg
-    end
-    if not new_diagnostics.options.color_warn.bg then
-      new_diagnostics.options.color_warn.bg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultWarningBg', 'bg') or
-              utils.extract_highlight_colors('DiffText', 'bg') or
-              Diagnostics.default_colors.warn.bg
-    end
+  if not new_diagnostics.options.color_error.bg then
+    new_diagnostics.options.color_error.bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultErrorBg', 'bg') or
+        Diagnostics.default_colors.error.bg
   end
-  if not new_diagnostics.options.color_info then
-    if not new_diagnostics.options.color_info.fg then
-      new_diagnostics.options.color_info.fg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultInformation', 'fg') or
-              utils.extract_highlight_colors('Normal', 'fg') or
-              Diagnostics.default_colors.info.fg
-    end
-    if not new_diagnostics.options.color_info.bg then
-      new_diagnostics.options.color_info.bg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultInformationBg', 'bg') or
-              utils.extract_highlight_colors('Normal', 'bg') or
-              Diagnostics.default_colors.info.bg
-    end
+  if not new_diagnostics.options.color_warn then new_diagnostics.options.color_warn = {} end
+  if not new_diagnostics.options.color_warn.fg then
+    new_diagnostics.options.color_warn.fg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
+            utils.extract_highlight_colors('DiffText', 'fg') or
+            Diagnostics.default_colors.warn.fg
   end
-  if not new_diagnostics.options.color_hint then
-    if not new_diagnostics.options.color_hint.fg then
-      new_diagnostics.options.color_hint.fg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'fg') or
-              utils.extract_highlight_colors('DiffChange', 'fg') or
-              Diagnostics.default_colors.hint.fg
-    end
-    if not new_diagnostics.options.color_hint.bg then
-      new_diagnostics.options.color_hint.bg =
-          utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'bg') or
-              utils.extract_highlight_colors('DiffChange', 'bg') or
-              Diagnostics.default_colors.hint.bg
-    end
+  if not new_diagnostics.options.color_warn.bg then
+    new_diagnostics.options.color_warn.bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultWarningBg', 'bg') or
+            utils.extract_highlight_colors('DiffText', 'bg') or
+            Diagnostics.default_colors.warn.bg
+  end
+  if not new_diagnostics.options.color_info then new_diagnostics.options.color_info = {} end
+  if not new_diagnostics.options.color_info.fg then
+    new_diagnostics.options.color_info.fg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultInformation', 'fg') or
+            utils.extract_highlight_colors('Normal', 'fg') or
+            Diagnostics.default_colors.info.fg
+  end
+  if not new_diagnostics.options.color_info.bg then
+    new_diagnostics.options.color_info.bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultInformationBg', 'bg') or
+            utils.extract_highlight_colors('Normal', 'bg') or
+            Diagnostics.default_colors.info.bg
+  end
+  if not new_diagnostics.options.color_hint then new_diagnostics.options.color_hint = {} end
+  if not new_diagnostics.options.color_hint.fg then
+    new_diagnostics.options.color_hint.fg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'fg') or
+            utils.extract_highlight_colors('DiffChange', 'fg') or
+            Diagnostics.default_colors.hint.fg
+  end
+  if not new_diagnostics.options.color_hint.bg then
+    new_diagnostics.options.color_hint.bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultHint', 'bg') or
+            utils.extract_highlight_colors('DiffChange', 'bg') or
+            Diagnostics.default_colors.hint.bg
   end
 
   if new_diagnostics.options.colored then

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -18,10 +18,10 @@ Diagnostics.default_colors = {
 Diagnostics.new = function(self, options, child)
   local new_diagnostics = self._parent:new(options, child or Diagnostics)
   local default_symbols = new_diagnostics.options.icons_enabled and {
-    error = ' ', -- xf659
-    warn = ' ', -- xf529
-    info = ' ', -- xf7fc
-    hint = ' ' -- xf838
+    error = '  ', -- xf659
+    warn = '  ', -- xf529
+    info = '  ', -- xf7fc
+    hint = '  ' -- xf838
   } or {error = 'E:', warn = 'W:', info = 'I:', hint = 'H:'}
   new_diagnostics.symbols = vim.tbl_extend('force', default_symbols,
                                            new_diagnostics.options.symbols or {})

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -7,7 +7,8 @@ local Diagnostics = require('lualine.component'):new()
 
 -- LuaFormatter off
 Diagnostics.default_colors = {
-  error = '#e32636',
+  error = '#000000',
+  error_bg = '#e06c75',
   warn  = '#ffdf00',
   info  = '#ffffff',
   hint  = '#d7afaf',

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -42,6 +42,11 @@ Diagnostics.new = function(self, options, child)
             utils.extract_highlight_colors('DiffDelete', 'fg') or
             Diagnostics.default_colors.error
   end
+  if not new_diagnostics.options.color_error_bg then
+    new_diagnostics.options.color_error_bg =
+        utils.extract_highlight_colors('LspDiagnosticsDefaultErrorBg', 'bg') or
+        Diagnostics.default_colors.error_bg
+  end
   if not new_diagnostics.options.color_warn then
     new_diagnostics.options.color_warn =
         utils.extract_highlight_colors('LspDiagnosticsDefaultWarning', 'fg') or
@@ -64,7 +69,7 @@ Diagnostics.new = function(self, options, child)
   if new_diagnostics.options.colored then
     new_diagnostics.highlight_groups = {
       error = highlight.create_component_highlight_group(
-          {fg = new_diagnostics.options.color_error}, 'diagnostics_error',
+          {fg = new_diagnostics.options.color_error, bg = new_diagnostics.options.color_error_bg}, 'diagnostics_error',
           new_diagnostics.options),
       warn = highlight.create_component_highlight_group(
           {fg = new_diagnostics.options.color_warn}, 'diagnostics_warn',


### PR DESCRIPTION
I did this pretty quickly, because I didn't like the contrast of the colors in the diagnostics section.
I realized there is no way to change the background colors.

If you are willing to merge this, then let me know first, and I will fix the documentation to match and make sure the tests are updated and pass.