### PR TITLE
Fixed using 'auto' theme with default colorscheme.

### DIFF
--- a/lua/lualine/themes/auto.lua
+++ b/lua/lualine/themes/auto.lua
@@ -117,7 +117,8 @@ local colors = {
 -- Change brightness of colors
 -- darken incase of light theme lighten incase of dark theme
 
-if get_color_brightness(utils.extract_highlight_colors('Normal', 'bg')) > 0.5 then
+local normal_color = utils.extract_highlight_colors('Normal', 'bg')
+if normal_color ~= nil and get_color_brightness(normal_color) > 0.5 then
   brightness_modifier_parameter = -brightness_modifier_parameter
 end
 


### PR DESCRIPTION
When setting theme to 'auto' and using the default colorscheme, lualine would report "theme not found, defaulting to gruvbox". Fixed by checking that we get an actual color back when calling utils.extract_highlight_colors before attempting to apply a brightness modifier.