### PR TITLE
Feature: Add Melange dark theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -125,6 +125,14 @@ lualine try to match your colorscheme.
 <img width='700' src='https://user-images.githubusercontent.com/41551030/108648935-a2dd0700-74bc-11eb-9a4b-72eb1e2ab79e.png'/>
 </p>
 
+### melange_dark
+<p>
+<img width='700' src='https://user-images.githubusercontent.com/6548350/133673183-7f9d6745-1a5d-4bc5-933c-a017ce3f2315.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/6548350/133673319-b4dee5de-1836-4776-a9ec-39a3c57eeb87.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/6548350/133673373-c777bdff-8076-4168-9b3b-ad6e1ad2fa0b.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/6548350/133673694-1736b8a2-43d1-4be2-a9b8-a5faf66eb26a.png'/>
+</p>
+
 ### modus_vivendi
 <p>
 <img width='700' src='https://user-images.githubusercontent.com/9327361/114389966-58176b80-9b9e-11eb-944e-1e0079527d74.png'/>

--- a/lua/lualine/themes/melange_dark.lua
+++ b/lua/lualine/themes/melange_dark.lua
@@ -1,0 +1,62 @@
+local colors = {
+	grays = {
+		bg = "#2A2622",
+		overbg = "#38332E",
+		sel = "#544A45",
+		com = "#998066",
+		faded = "#C9B39C",
+		fg = "#EDE6DE",
+	},
+	shades = {
+		red = "#6B2E2E",
+		yellow = "#997733",
+		green = "#244224",
+		cyan = "#244242",
+		blue = "#242E42",
+		magenta = "#422438",
+	},
+	tones = {
+		red = "#B34D4D",
+		yellow = "#E09952",
+		green = "#669966",
+		cyan = "#85ADAD",
+		blue = "#5973A6",
+		magenta = "#AD85AD",
+	},
+	tints = {
+		red = "#F7856E",
+		yellow = "#F7C96E",
+		green = "#94D194",
+		cyan = "#94D1D1",
+		blue = "#94A8D1",
+		magenta = "#D194BD",
+	},
+}
+
+return {
+	normal = {
+		a = { bg = colors.shades.cyan, fg = colors.tints.cyan, gui = "bold" },
+		b = { bg = colors.grays.sel, fg = colors.grays.faded },
+		c = { bg = colors.grays.overbg, fg = colors.grays.com, gui = "italic" },
+	},
+	insert = {
+		a = { bg = colors.shades.yellow, fg = colors.tints.yellow, gui = "bold" },
+	},
+	replace = {
+		a = { bg = colors.shades.red, fg = colors.tints.red, gui = "bold" },
+	},
+	visual = {
+		a = { bg = colors.shades.magenta, fg = colors.tints.magenta, gui = "bold" },
+	},
+	command = {
+		a = { bg = colors.shades.green, fg = colors.tints.green, gui = "bold" },
+	},
+	terminal = {
+		a = { bg = colors.shades.green, fg = colors.tints.green, gui = "bold" },
+	},
+	inactive = {
+		a = { bg = colors.grays.overbg, fg = colors.grays.sel, gui = "italic" },
+		b = { bg = colors.grays.overbg, fg = colors.grays.sel, gui = "italic" },
+		c = { bg = colors.grays.overbg, fg = colors.grays.sel, gui = "italic" },
+	},
+}


### PR DESCRIPTION
Adds a new theme, `melange_dark`, based on the dark variant of the [Melange](https://github.com/savq/melange) theme for NeoVim. I've been using this theme myself for a bit now and thought others might enjoy it 😄 

cc @savq