### PR TITLE
Adding modus operandi theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -125,6 +125,14 @@ lualine try to match your colorscheme.
 <img width='700' src='https://user-images.githubusercontent.com/41551030/108648935-a2dd0700-74bc-11eb-9a4b-72eb1e2ab79e.png'/>
 </p>
 
+### modus_operandi
+<p>
+<img width='700' src='https://user-images.githubusercontent.com/33635216/134817118-d0f7b741-36fc-4fd7-8a70-b07ab0a35c74.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/33635216/134817159-db9dac36-8edb-4089-bec1-ed2bc2f26d4d.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/33635216/134817178-63fd0851-d41f-4150-b6b9-5b81b1d25930.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/33635216/134817215-776c883e-4f23-443b-9db6-7f77e494418c.png'/>
+</p>
+
 ### modus_vivendi
 <p>
 <img width='700' src='https://user-images.githubusercontent.com/9327361/114389966-58176b80-9b9e-11eb-944e-1e0079527d74.png'/>

--- a/lua/lualine/themes/modus_operandi.lua
+++ b/lua/lualine/themes/modus_operandi.lua
@@ -1,0 +1,54 @@
+-- Copyright (c) 2020-2021 allumik
+-- MIT license, see LICENSE for more details.
+-- LuaFormatter off
+local colors = {
+  black = '#000000',
+  white = '#ffffff',
+  red = '#7f1010',
+  green = '#104410',
+  blue = '#003497',
+  magenta = '#752f50',
+  cyan = '#005077',
+  gray = '#e0e0e0',
+  darkgray = '#404148',
+  lightgray = '#efefef'
+}
+-- LuaFormatter on
+
+return {
+  normal = {
+      a = {bg = colors.blue, fg = colors.lightgray, gui = 'bold'},
+      b = {bg = colors.lightgray, fg = colors.blue},
+      c = {bg = colors.gray, fg = colors.white}
+  },
+
+  insert = {
+      a = {bg = colors.cyan, fg = colors.lightgray, gui = 'bold'},
+      b = {bg = colors.lightgray, fg = colors.cyan},
+      c = {bg = colors.gray, fg = colors.white}
+  },
+
+  visual = {
+      a = {bg = colors.magenta, fg = colors.lightgray, gui = 'bold'},
+      b = {bg = colors.lightgray, fg = colors.magenta},
+      c = {bg = colors.gray, fg = colors.white}
+  },
+
+  replace = {
+      a = {bg = colors.red, fg = colors.lightgray, gui = 'bold'},
+      b = {bg = colors.lightgray, fg = colors.red},
+      c = {bg = colors.gray, fg = colors.white}
+  },
+
+  command = {
+      a = {bg = colors.green, fg = colors.lightgray, gui = 'bold'},
+      b = {bg = colors.lightgray, fg = colors.green},
+      c = {bg = colors.gray, fg = colors.white}
+  },
+
+  inactive = {
+      a = {bg = colors.darkgray, fg = colors.lightgray, gui = 'bold'},
+      b = {bg = colors.darkgray, fg = colors.lightgray},
+      c = {bg = colors.darkgray, fg = colors.lightgray}
+  }
+}

--- a/lua/lualine/themes/modus_operandi.lua
+++ b/lua/lualine/themes/modus_operandi.lua
@@ -20,27 +20,27 @@ return {
   normal = {
     a = {bg = colors.blue, fg = colors.lightgray, gui = 'bold'},
     b = {bg = colors.lightgray, fg = colors.blue},
-    c = {bg = colors.gray, fg = colors.white}
+    c = {bg = colors.gray, fg = colors.darkgray}
   },
   insert = {
     a = {bg = colors.cyan, fg = colors.lightgray, gui = 'bold'},
     b = {bg = colors.lightgray, fg = colors.cyan},
-    c = {bg = colors.gray, fg = colors.white}
+    c = {bg = colors.gray, fg = colors.darkgray}
   },
   visual = {
     a = {bg = colors.magenta, fg = colors.lightgray, gui = 'bold'},
     b = {bg = colors.lightgray, fg = colors.magenta},
-    c = {bg = colors.gray, fg = colors.white}
+    c = {bg = colors.gray, fg = colors.darkgray}
   },
   replace = {
     a = {bg = colors.red, fg = colors.lightgray, gui = 'bold'},
     b = {bg = colors.lightgray, fg = colors.red},
-    c = {bg = colors.gray, fg = colors.white}
+    c = {bg = colors.gray, fg = colors.darkgray}
   },
   command = {
     a = {bg = colors.green, fg = colors.lightgray, gui = 'bold'},
     b = {bg = colors.lightgray, fg = colors.green},
-    c = {bg = colors.gray, fg = colors.white}
+    c = {bg = colors.gray, fg = colors.darkgray}
   },
   inactive = {
     a = {bg = colors.darkgray, fg = colors.lightgray, gui = 'bold'},

--- a/lua/lualine/themes/modus_operandi.lua
+++ b/lua/lualine/themes/modus_operandi.lua
@@ -1,5 +1,6 @@
 -- Copyright (c) 2020-2021 allumik
 -- MIT license, see LICENSE for more details.
+-- Credit: ronniedroid (modus_vivendi theme)
 -- LuaFormatter off
 local colors = {
   black = '#000000',
@@ -17,38 +18,33 @@ local colors = {
 
 return {
   normal = {
-      a = {bg = colors.blue, fg = colors.lightgray, gui = 'bold'},
-      b = {bg = colors.lightgray, fg = colors.blue},
-      c = {bg = colors.gray, fg = colors.white}
+    a = {bg = colors.blue, fg = colors.lightgray, gui = 'bold'},
+    b = {bg = colors.lightgray, fg = colors.blue},
+    c = {bg = colors.gray, fg = colors.white}
   },
-
   insert = {
-      a = {bg = colors.cyan, fg = colors.lightgray, gui = 'bold'},
-      b = {bg = colors.lightgray, fg = colors.cyan},
-      c = {bg = colors.gray, fg = colors.white}
+    a = {bg = colors.cyan, fg = colors.lightgray, gui = 'bold'},
+    b = {bg = colors.lightgray, fg = colors.cyan},
+    c = {bg = colors.gray, fg = colors.white}
   },
-
   visual = {
-      a = {bg = colors.magenta, fg = colors.lightgray, gui = 'bold'},
-      b = {bg = colors.lightgray, fg = colors.magenta},
-      c = {bg = colors.gray, fg = colors.white}
+    a = {bg = colors.magenta, fg = colors.lightgray, gui = 'bold'},
+    b = {bg = colors.lightgray, fg = colors.magenta},
+    c = {bg = colors.gray, fg = colors.white}
   },
-
   replace = {
-      a = {bg = colors.red, fg = colors.lightgray, gui = 'bold'},
-      b = {bg = colors.lightgray, fg = colors.red},
-      c = {bg = colors.gray, fg = colors.white}
+    a = {bg = colors.red, fg = colors.lightgray, gui = 'bold'},
+    b = {bg = colors.lightgray, fg = colors.red},
+    c = {bg = colors.gray, fg = colors.white}
   },
-
   command = {
-      a = {bg = colors.green, fg = colors.lightgray, gui = 'bold'},
-      b = {bg = colors.lightgray, fg = colors.green},
-      c = {bg = colors.gray, fg = colors.white}
+    a = {bg = colors.green, fg = colors.lightgray, gui = 'bold'},
+    b = {bg = colors.lightgray, fg = colors.green},
+    c = {bg = colors.gray, fg = colors.white}
   },
-
   inactive = {
-      a = {bg = colors.darkgray, fg = colors.lightgray, gui = 'bold'},
-      b = {bg = colors.darkgray, fg = colors.lightgray},
-      c = {bg = colors.darkgray, fg = colors.lightgray}
+    a = {bg = colors.darkgray, fg = colors.lightgray, gui = 'bold'},
+    b = {bg = colors.darkgray, fg = colors.lightgray},
+    c = {bg = colors.darkgray, fg = colors.lightgray}
   }
 }


### PR DESCRIPTION
In addition to the existing [`modus vivendi`](https://github.com/hoob3rt/lualine.nvim/blob/master/THEMES.md#modus_vivendi) theme, the light version aka `modus operandi` theme is added in this PR.

The theme was mostly copied from the `modus_vivendi.lua` by @ronniedroid with colors adjusted accoring to [original Emacs theme](https://github.com/protesilaos/modus-themes/blob/main/modus-themes.el).