### PR TITLE
Prevent E5108 when leaving LSP buffer that is not connected to a file

### DIFF
--- a/lua/lualine/init.lua
+++ b/lua/lualine/init.lua
@@ -169,8 +169,8 @@ local function set_statusline()
     vim.api.nvim_exec([[
       augroup lualine
         autocmd!
-        autocmd WinLeave,BufLeave * lua vim.wo.statusline=require'lualine'.statusline()
-        autocmd BufWinEnter,WinEnter,BufEnter * set statusline<
+        autocmd WinLeave,BufLeave * silent! lua vim.wo.statusline=require'lualine'.statusline()
+        autocmd BufWinEnter,WinEnter,BufEnter * silent! set statusline<
         autocmd VimResized * redrawstatus
       augroup END
     ]], false)


### PR DESCRIPTION
### Background
When leaving a buffer without a proper file handle (e.g. a buffer containing decompiled java sources accessed via nvim LSP) I get the following error:
```
Error detected while processing BufLeave Autocommands for "*":
E5108: Error executing lua [string ":lua"]:1: E539: Illegal character <C>
```

### Changes
- Add `silent!` to affected `autocmd` declarations