### PR TITLE
Add option to show diagnostics even if the count is 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,8 @@ sections = {
       color_warn = nil, -- changes diagnostic's warn foreground color
       color_info = nil, -- Changes diagnostic's info foreground color
       color_hint = nil, -- Changes diagnostic's hint foreground color
-      symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'}
+      symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'},
+      visible = nil, -- show diagnostics even if 0, boolean or function returning boolean
     }
   }
 }

--- a/doc/lualine.txt
+++ b/doc/lualine.txt
@@ -233,7 +233,8 @@ Component specific local options~
         color_warn = nil, -- changes diagnostic's warn foreground color
         color_info = nil, -- Changes diagnostic's info foreground color
         color_hint = nil, -- Changes diagnostic's hint foreground color
-        symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'}
+        symbols = {error = 'E', warn = 'W', info = 'I', hint = 'H'},
+        visible = nil, -- show diagnostics even if 0, boolean or function returning boolean
       }
     }
   }

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -97,20 +97,24 @@ Diagnostics.update_status = function(self)
     info = info_count,
     hint = hint_count
   }
+  local visible = self.options.visible == "always"
+  if type(self.options.visible == "function") then
+    visible = self.options.visible()
+  end
   if self.options.colored then
     local colors = {}
     for name, hl in pairs(self.highlight_groups) do
       colors[name] = highlight.component_format_highlight(hl)
     end
     for _, section in ipairs(self.options.sections) do
-      if data[section] ~= nil and data[section] > 0 then
+      if data[section] ~= nil and (visible or data[section] > 0) then
         table.insert(result,
                      colors[section] .. self.symbols[section] .. data[section])
       end
     end
   else
     for _, section in ipairs(self.options.sections) do
-      if data[section] ~= nil and data[section] > 0 then
+      if data[section] ~= nil and (visible or data[section] > 0) then
         table.insert(result, self.symbols[section] .. data[section])
       end
     end

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -98,7 +98,7 @@ Diagnostics.update_status = function(self)
     hint = hint_count
   }
   local visible = self.options.visible == true
-  if type(self.options.visible == "function") then
+  if type(self.options.visible) == "function" then
     visible = self.options.visible()
   end
   if self.options.colored then

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -97,7 +97,7 @@ Diagnostics.update_status = function(self)
     info = info_count,
     hint = hint_count
   }
-  local visible = self.options.visible == "always"
+  local visible = self.options.visible == true
   if type(self.options.visible == "function") then
     visible = self.options.visible()
   end


### PR DESCRIPTION
Adds a component-specific `visible` option to the diagnostics component that allows you to show diagnostics when the diagnostics count is zero.

Can be a boolean, or a function returning a boolean.